### PR TITLE
Add self-update command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           GH_TOKEN: ${{ secrets.TAP_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
-          VERSION="${TAG#v.}"
+          VERSION="${TAG#v}"
           gh api repos/httphatch/homebrew-tap/dispatches \
             -f event_type=formula-update \
             -f 'client_payload[version]'="${VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS := -s -w \
 	-X github.com/httphatch/hatch/cmd.commit=$(COMMIT) \
 	-X github.com/httphatch/hatch/cmd.date=$(DATE)
 
-.PHONY: build build-test run test clean app frontend icon
+.PHONY: build build-test run test lint clean app frontend icon
 
 build:
 	go build -ldflags '$(LDFLAGS)' -o hatch .
@@ -20,6 +20,9 @@ run:
 
 test:
 	go test ./...
+
+lint:
+	golangci-lint run
 
 frontend:
 	cd frontend && npm install && VITE_APP_VERSION=$(VERSION) npm run build

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,15 +3,20 @@ package cmd
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"sort"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/daemon"
+	"github.com/httphatch/hatch/internal/update"
 )
 
 var statusCmd = &cobra.Command{
@@ -35,6 +40,15 @@ func runStatus() error {
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgRed).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
+
+	// Start update check in background so it doesn't block output.
+	var updateHint string
+	var updateWg sync.WaitGroup
+	updateWg.Add(1)
+	go func() {
+		defer updateWg.Done()
+		updateHint = checkUpdateHint()
+	}()
 
 	// Daemon state
 	running, pid, _ := daemon.IsRunning()
@@ -127,6 +141,11 @@ func runStatus() error {
 		}
 	}
 
+	updateWg.Wait()
+	if updateHint != "" {
+		fmt.Print(updateHint)
+	}
+
 	return nil
 }
 
@@ -166,4 +185,33 @@ func resolveDomain(proj config.Project, svc config.Service) string {
 		return svc.Subdomain + "." + proj.Domain
 	}
 	return proj.Domain
+}
+
+// checkUpdateHint silently checks for a newer version and returns a
+// formatted hint string, or empty if up to date / check fails.
+func checkUpdateHint() string {
+	currentRaw := strings.TrimPrefix(version, "v")
+	current, err := semver.NewVersion(currentRaw)
+	if err != nil {
+		return ""
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	rel, err := update.CheckLatest(client)
+	if err != nil {
+		return ""
+	}
+
+	latestRaw := strings.TrimPrefix(rel.TagName, "v")
+	latest, err := semver.NewVersion(latestRaw)
+	if err != nil {
+		return ""
+	}
+
+	if current.LessThan(latest) {
+		yellow := color.New(color.FgYellow).SprintFunc()
+		return fmt.Sprintf("\n%s Update available: v%s → v%s (run 'hatch update')\n",
+			yellow("!"), current, latest)
+	}
+	return ""
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,24 +2,121 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/httphatch/hatch/internal/daemon"
+	"github.com/httphatch/hatch/internal/update"
 )
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update Hatch to the latest version",
-	Run: func(cmd *cobra.Command, args []string) {
-		name := color.New(color.FgCyan, color.Bold).Sprint("Hatch")
-		ver := color.New(color.FgGreen).Sprint(version)
-		fmt.Printf("%s %s\n", name, ver)
-		fmt.Println()
-		yellow := color.New(color.FgYellow).SprintFunc()
-		fmt.Printf("%s Self-update is not yet available.\n", yellow("!"))
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUpdate()
+	},
+}
+
+func runUpdate() error {
+	yellow := color.New(color.FgYellow).SprintFunc()
+	green := color.New(color.FgGreen).SprintFunc()
+
+	// Parse current version.
+	currentRaw := strings.TrimPrefix(version, "v")
+	current, err := semver.NewVersion(currentRaw)
+	if err != nil {
+		fmt.Printf("%s Running a dev build (%s) — cannot self-update.\n", yellow("!"), version)
 		fmt.Println("  Download the latest release from:")
 		fmt.Println("  https://github.com/httphatch/hatch/releases")
-	},
+		return nil
+	}
+
+	// Check for Homebrew install.
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("detect executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("resolve symlinks: %w", err)
+	}
+
+	if update.IsHomebrew(execPath) {
+		fmt.Printf("%s Installed via Homebrew. Run: %s\n", yellow("!"), color.CyanString("brew upgrade hatch"))
+		return nil
+	}
+
+	// Fetch latest release.
+	fmt.Println("Checking for updates...")
+	rel, err := update.CheckLatest(nil)
+	if err != nil {
+		return fmt.Errorf("check for updates: %w", err)
+	}
+
+	latestRaw := strings.TrimPrefix(rel.TagName, "v")
+	latest, err := semver.NewVersion(latestRaw)
+	if err != nil {
+		return fmt.Errorf("parse latest version %q: %w", rel.TagName, err)
+	}
+
+	if !current.LessThan(latest) {
+		fmt.Printf("%s Hatch %s is already up to date.\n", green("✓"), version)
+		return nil
+	}
+
+	// Find matching asset.
+	asset, err := update.AssetForArch(rel.Assets)
+	if err != nil {
+		return fmt.Errorf("find download: %w", err)
+	}
+
+	// Download new binary.
+	fmt.Printf("Downloading %s...\n", rel.TagName)
+	tmpPath, err := update.Download(nil, asset.BrowserDownloadURL, filepath.Dir(execPath))
+	if err != nil {
+		return fmt.Errorf("download update: %w", err)
+	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// Check if daemon is running so we can restart after update.
+	wasRunning, _, _ := daemon.IsRunning()
+
+	if wasRunning {
+		fmt.Println("Stopping daemon...")
+		if err := runDown(); err != nil {
+			return fmt.Errorf("stop daemon: %w", err)
+		}
+	}
+
+	// Apply update (atomic replace).
+	if err := update.Apply(execPath, tmpPath); err != nil {
+		return fmt.Errorf("apply update: %w", err)
+	}
+	cleanup = false
+
+	if wasRunning {
+		fmt.Println("Restarting daemon...")
+		if err := runUp(); err != nil {
+			return fmt.Errorf("restart daemon: %w", err)
+		}
+	}
+
+	fmt.Printf("\n%s Updated Hatch %s → %s\n",
+		green("✓"),
+		color.New(color.FgWhite).Sprintf("v%s", current),
+		color.New(color.FgGreen).Sprintf("v%s", latest),
+	)
+	return nil
 }
 
 func init() {

--- a/internal/tray/manager.go
+++ b/internal/tray/manager.go
@@ -110,7 +110,7 @@ func (m *Manager) Stop() {
 		close(m.done)
 	}
 	if m.checker != nil {
-		m.checker.Stop()
+		_ = m.checker.Stop()
 	}
 	if m.tray != nil {
 		m.tray.Destroy()
@@ -239,7 +239,7 @@ func (m *Manager) buildProjectItem(menu *application.Menu, name string, proj con
 	// Open in Browser.
 	sub.Add("Open in Browser").OnClick(func(_ *application.Context) {
 		u := url.URL{Scheme: "https", Host: domain}
-		browser.OpenURL(u.String())
+		_ = browser.OpenURL(u.String())
 	})
 
 	// Enable / Disable toggle.

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,142 @@
+package update
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const releasesURL = "https://api.github.com/repos/httphatch/hatch/releases/latest"
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type Release struct {
+	TagName string  `json:"tag_name"`
+	Assets  []Asset `json:"assets"`
+}
+
+// CheckLatest fetches the latest release from GitHub. The caller may set a
+// timeout on the provided http.Client (e.g. 3 s for a background check).
+func CheckLatest(client *http.Client) (*Release, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	req, err := http.NewRequest("GET", releasesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "hatch-updater")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch latest release: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github api: status %d", resp.StatusCode)
+	}
+
+	var rel Release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decode release: %w", err)
+	}
+	return &rel, nil
+}
+
+// AssetForArch returns the asset matching the current darwin architecture.
+func AssetForArch(assets []Asset) (*Asset, error) {
+	target := fmt.Sprintf("hatch-darwin-%s", runtime.GOARCH)
+	for _, a := range assets {
+		if a.Name == target {
+			return &a, nil
+		}
+	}
+	return nil, fmt.Errorf("no asset found for %s", target)
+}
+
+var allowedDownloadHosts = map[string]bool{
+	"github.com":                    true,
+	"objects.githubusercontent.com": true,
+}
+
+// Download fetches downloadURL into a temporary file in destDir,
+// returning the temp file path.
+func Download(client *http.Client, downloadURL, destDir string) (string, error) {
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+
+	parsed, err := url.Parse(downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("parse download url: %w", err)
+	}
+	if !allowedDownloadHosts[parsed.Hostname()] {
+		return "", fmt.Errorf("untrusted download host: %s", parsed.Hostname())
+	}
+
+	resp, err := client.Get(downloadURL)
+	if err != nil {
+		return "", fmt.Errorf("download binary: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download: status %d", resp.StatusCode)
+	}
+
+	tmp, err := os.CreateTemp(destDir, "hatch-update-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp file: %w", err)
+	}
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("write binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("close temp file: %w", err)
+	}
+
+	return tmp.Name(), nil
+}
+
+// Apply replaces the binary at binaryPath with the new binary at newPath.
+// Uses an atomic os.Rename to avoid leaving the user without a binary.
+func Apply(binaryPath, newPath string) error {
+	if err := os.Chmod(newPath, 0o755); err != nil {
+		return fmt.Errorf("chmod new binary: %w", err)
+	}
+
+	if err := os.Rename(newPath, binaryPath); err != nil {
+		return fmt.Errorf("install new binary: %w", err)
+	}
+
+	return nil
+}
+
+// IsHomebrew returns true if the binary path looks like a Homebrew install.
+func IsHomebrew(execPath string) bool {
+	dir := filepath.Clean(execPath)
+	for dir != "/" && dir != "." {
+		base := filepath.Base(dir)
+		if base == "Cellar" || base == "homebrew" {
+			return true
+		}
+		dir = filepath.Dir(dir)
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Implement `hatch update` — downloads the latest release from GitHub and atomically replaces the binary, with daemon stop/restart
- Add async update hint to `hatch status` (non-blocking, 3s timeout)
- Fix version tag format from `v.X.X.X` to `vX.X.X` in release workflow
- Add `make lint` target for local golangci-lint
- Detect Homebrew installs and point users to `brew upgrade` instead
- Validate download URLs against GitHub host allowlist

## Design decisions

- **Atomic replacement**: Single `os.Rename` to avoid TOCTOU window
- **No checksum verification**: Relies on HTTPS transport security (consistent with `gh`, `golangci-lint`)
- **Homebrew detection**: Walks path components looking for `Cellar` or `homebrew`

## Test plan

- [x] `make build && ./hatch version` — builds and prints version
- [x] `./hatch update` — detects dev build, prints fallback message
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — clean
- [x] `make lint` — 0 issues

Closes #1