### PR TITLE
Add README and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Hatch
+
+Local HTTPS development for macOS.
+
+Hatch gives every local project a clean `.test` domain with trusted HTTPS. It manages DNS resolution, TLS certificates, and reverse proxying so you can work with `https://myapp.test` instead of `localhost:3000`.
+
+## Install
+
+### Homebrew (recommended)
+
+```bash
+brew install httphatch/tap/hatch
+```
+
+### From source
+
+Requires Go 1.25+.
+
+```bash
+git clone https://github.com/httphatch/hatch.git
+cd hatch
+make build
+sudo ln -sf "$(pwd)/hatch" /usr/local/bin/hatch
+```
+
+## Quick start
+
+```bash
+# One-time setup — creates certs, trusts CA, installs DNS resolver
+hatch init
+
+# Start the daemon
+hatch up
+
+# Add a project
+hatch add myapp --proxy http://localhost:3000
+
+# Open it
+hatch open myapp
+# → https://myapp.test with a green lock
+```
+
+## Multi-service projects
+
+Create a `.hatch.yml` in your project root:
+
+```yaml
+domain: myapp.test
+services:
+  frontend:
+    proxy: http://localhost:3000
+  api:
+    proxy: http://localhost:8080
+    subdomain: api
+  docs:
+    proxy: http://localhost:4000
+    route: /docs
+```
+
+Then link it:
+
+```bash
+cd ~/projects/myapp
+hatch link
+```
+
+This gives you:
+- `https://myapp.test` → frontend on port 3000
+- `https://api.myapp.test` → API on port 8080
+- `https://myapp.test/docs/*` → docs on port 4000
+
+## Documentation
+
+Full docs at [httphatch.com](https://httphatch.com):
+
+- [Getting Started](https://httphatch.com/guide/getting-started) — install, init, first project
+- [CLI Reference](https://httphatch.com/reference/cli) — all commands and flags
+- [Configuration](https://httphatch.com/reference/config) — global config options
+- [.hatch.yml](https://httphatch.com/reference/hatch-yml) — per-project config format
+- [How It Works](https://httphatch.com/advanced/how-it-works) — architecture and internals
+- [Troubleshooting](https://httphatch.com/advanced/troubleshooting) — common issues and fixes
+
+## License
+
+[MIT](LICENSE)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,34 @@
+# Hatch
+
+> Local HTTPS development for macOS — automatic DNS, trusted certificates, and reverse proxying for .test domains.
+
+Hatch is a local development environment tool for macOS. It runs as a background daemon that provides DNS resolution, TLS certificate management, and HTTPS reverse proxying so that local projects are accessible via clean `.test` domains (e.g., `https://myapp.test`) with trusted certificates.
+
+Key concepts:
+- **Daemon**: A single background process (managed via launchd) that runs the DNS server, certificate authority, and reverse proxy.
+- **Projects**: Each project maps a `.test` domain to one or more local services. Projects are added with `hatch add` or by linking a `.hatch.yml` config file.
+- **Services**: Each project has one or more services, each proxying to a local upstream (e.g., `http://localhost:3000`). Services can be routed by path prefix or subdomain.
+- **Certificates**: Hatch generates a local root CA and intermediate CA, trusted in the macOS Keychain. Per-domain certificates are issued automatically.
+- **DNS**: A local DNS server resolves `*.test` to localhost via a macOS resolver config in `/etc/resolver/`.
+
+## Guide
+
+- [What is Hatch?](https://httphatch.com/guide/what-is-hatch): Feature overview and how Hatch compares to editing /etc/hosts or using self-signed certificates.
+- [Getting Started](https://httphatch.com/guide/getting-started): Installation (Homebrew or source), first-time setup with `hatch init`, starting the daemon, and adding your first project.
+- [Dashboard](https://httphatch.com/guide/dashboard): Visual GUI for managing projects, viewing logs, and monitoring service health.
+
+## Reference
+
+- [CLI](https://httphatch.com/reference/cli): Complete command reference — daemon management (`up`, `down`, `restart`, `status`, `logs`), project management (`add`, `link`, `unlink`, `list`, `remove`, `enable`, `disable`, `open`), system setup (`init`, `trust`, `doctor`, `clean`), and config commands.
+- [Configuration](https://httphatch.com/reference/config): Global config file (`~/.hatch/config.yml`) — TLD, HTTP/HTTPS ports, auto-start, log level, and project/service definitions.
+- [.hatch.yml](https://httphatch.com/reference/hatch-yml): Per-project config file format — domain, services with proxy, route, subdomain, and websocket options.
+
+## Advanced
+
+- [How It Works](https://httphatch.com/advanced/how-it-works): Architecture internals — embedded Caddy server, DNS resolver integration, certificate chain, launchd lifecycle, and live config reloading.
+- [Troubleshooting](https://httphatch.com/advanced/troubleshooting): Common issues and diagnostic steps — `hatch doctor`, port conflicts, DNS resolution failures, certificate trust problems.
+
+## Community
+
+- [Contributing](https://httphatch.com/contributing): Development setup, code conventions, and how to submit changes.
+- [GitHub](https://github.com/httphatch/hatch): Source code and issue tracker.


### PR DESCRIPTION
## Summary
- Add `README.md` with install instructions, quick start, multi-service example, and doc links
- Add `docs/public/llms.txt` for LLM discovery at httphatch.com/llms.txt following the llms.txt spec

Closes #6