### PR TITLE
Add process management for local dev services

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -216,6 +217,43 @@ func (s *Server) handleToggleProject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]bool{"enabled": proj.Enabled})
+}
+
+func (s *Server) handleProcesses(w http.ResponseWriter, r *http.Request) {
+	if s.processes == nil {
+		writeJSON(w, http.StatusOK, []any{})
+		return
+	}
+
+	statuses := s.processes.Statuses()
+
+	type processInfo struct {
+		Project   string `json:"project"`
+		Service   string `json:"service"`
+		Command   string `json:"command"`
+		Running   bool   `json:"running"`
+		Restarts  int    `json:"restarts"`
+		StartedAt string `json:"started_at"`
+	}
+
+	result := make([]processInfo, 0, len(statuses))
+	for id, st := range statuses {
+		result = append(result, processInfo{
+			Project:   id.Project,
+			Service:   id.Service,
+			Command:   st.Command,
+			Running:   st.Running,
+			Restarts:  st.Restarts,
+			StartedAt: st.StartedAt.Format(time.RFC3339),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Project != result[j].Project {
+			return result[i].Project < result[j].Project
+		}
+		return result[i].Service < result[j].Service
+	})
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/httphatch/hatch/internal/certs"
 	"github.com/httphatch/hatch/internal/health"
+	"github.com/httphatch/hatch/internal/process"
 )
 
 // DaemonControl allows the API to trigger daemon operations.
@@ -19,11 +20,17 @@ type DaemonControl interface {
 	ReloadConfig() error
 }
 
+// ProcessStatuser provides a snapshot of managed process statuses.
+type ProcessStatuser interface {
+	Statuses() map[process.ServiceID]process.ProcessStatus
+}
+
 // Server is the HTTP API server for the Hatch dashboard.
 type Server struct {
 	httpSrv   *http.Server
 	daemon    DaemonControl
 	health    *health.Checker
+	processes ProcessStatuser
 	caPaths   certs.CAPaths
 	version   string
 	startTime time.Time
@@ -35,6 +42,7 @@ type Server struct {
 type ServerConfig struct {
 	Addr      string
 	Health    *health.Checker
+	Processes ProcessStatuser
 	Daemon    DaemonControl
 	CAPaths   certs.CAPaths
 	Version   string
@@ -47,6 +55,7 @@ func NewServer(cfg ServerConfig) *Server {
 	s := &Server{
 		daemon:    cfg.Daemon,
 		health:    cfg.Health,
+		processes: cfg.Processes,
 		caPaths:   cfg.CAPaths,
 		version:   cfg.Version,
 		startTime: cfg.StartTime,
@@ -95,6 +104,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/projects/{name}", s.handleDeleteProject)
 	mux.HandleFunc("PATCH /api/projects/{name}/toggle", s.handleToggleProject)
 	mux.HandleFunc("GET /api/health", s.handleHealth)
+	mux.HandleFunc("GET /api/processes", s.handleProcesses)
 	mux.HandleFunc("GET /api/logs", s.handleLogs)
 	mux.HandleFunc("GET /api/config", s.handleGetConfig)
 	mux.HandleFunc("PUT /api/config", s.handlePutConfig)

--- a/internal/caddy/translate.go
+++ b/internal/caddy/translate.go
@@ -85,6 +85,9 @@ func buildRoutes(cfg config.Config) []map[string]any {
 			continue
 		}
 		for _, svc := range proj.Services {
+			if svc.Proxy == "" {
+				continue
+			}
 			domain := proj.Domain
 			if svc.Subdomain != "" {
 				domain = svc.Subdomain + "." + proj.Domain
@@ -258,9 +261,11 @@ func collectDomains(cfg config.Config) []string {
 		if !proj.Enabled {
 			continue
 		}
-		domainSet[proj.Domain] = true
-
 		for _, svc := range proj.Services {
+			if svc.Proxy == "" {
+				continue
+			}
+			domainSet[proj.Domain] = true
 			if svc.Subdomain != "" {
 				domainSet[svc.Subdomain+"."+proj.Domain] = true
 			}

--- a/internal/caddy/translate_test.go
+++ b/internal/caddy/translate_test.go
@@ -622,6 +622,87 @@ func TestTranslate_GoldenFile(t *testing.T) {
 	}
 }
 
+func TestTranslate_CommandOnlyServiceSkipped(t *testing.T) {
+	cfg := config.Config{
+		Version: 1,
+		Settings: config.Settings{
+			HTTPPort:  80,
+			HTTPSPort: 443,
+		},
+		Projects: map[string]config.Project{
+			"myapp": {
+				Domain:  "myapp.test",
+				Path:    "/path/to/myapp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"web":    {Proxy: "http://localhost:3000", Command: "npm start"},
+					"worker": {Command: "php artisan queue:work"},
+				},
+			},
+		},
+	}
+
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+
+	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
+	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
+
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route (command-only skipped), got %d", len(routes))
+	}
+
+	host := routes[0]["match"].([]map[string]any)[0]["host"].([]string)[0]
+	if host != "myapp.test" {
+		t.Errorf("expected host myapp.test, got %s", host)
+	}
+
+	// Domains should only include myapp.test (not a domain for the worker).
+	tls := result["apps"].(map[string]any)["tls"].(map[string]any)
+	policies := tls["automation"].(map[string]any)["policies"].([]map[string]any)
+	if len(policies) != 1 {
+		t.Fatalf("expected 1 TLS policy, got %d", len(policies))
+	}
+	subjects := policies[0]["subjects"].([]string)
+	if len(subjects) != 1 || subjects[0] != "myapp.test" {
+		t.Errorf("expected [myapp.test], got %v", subjects)
+	}
+}
+
+func TestTranslate_AllCommandOnlyProject(t *testing.T) {
+	cfg := config.Config{
+		Version: 1,
+		Settings: config.Settings{
+			HTTPPort:  80,
+			HTTPSPort: 443,
+		},
+		Projects: map[string]config.Project{
+			"myapp": {
+				Domain:  "myapp.test",
+				Path:    "/path/to/myapp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"worker": {Command: "php artisan queue:work"},
+				},
+			},
+		},
+	}
+
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+
+	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
+	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
+
+	if len(routes) != 0 {
+		t.Errorf("expected 0 routes for command-only project, got %d", len(routes))
+	}
+
+	tls := result["apps"].(map[string]any)["tls"].(map[string]any)
+	policies := tls["automation"].(map[string]any)["policies"].([]map[string]any)
+	if len(policies) != 0 {
+		t.Errorf("expected 0 TLS policies, got %d", len(policies))
+	}
+}
+
 func TestExtractDialAddress(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -24,12 +24,14 @@ type Project struct {
 	Services map[string]Service `yaml:"services" json:"services"`
 }
 
-// Service defines how a single service is proxied.
+// Service defines how a single service is proxied and optionally managed.
 type Service struct {
-	Proxy     string `yaml:"proxy" json:"proxy"`
+	Proxy     string `yaml:"proxy,omitempty" json:"proxy,omitempty"`
+	Command   string `yaml:"command,omitempty" json:"command,omitempty"`
 	Route     string `yaml:"route,omitempty" json:"route,omitempty"`
 	Subdomain string `yaml:"subdomain,omitempty" json:"subdomain,omitempty"`
 	WebSocket bool   `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+	EnvFile   string `yaml:"env_file,omitempty" json:"env_file,omitempty"`
 }
 
 // ProjectConfig is the schema for a per-project .hatch.yml file.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -108,19 +109,39 @@ func validateService(prefix, name string, s Service) []error {
 	var errs []error
 	svcPrefix := fmt.Sprintf("%s.services.%s", prefix, name)
 
-	// Proxy URL
-	if s.Proxy == "" {
-		errs = append(errs, fmt.Errorf("%s.proxy is required", svcPrefix))
-	} else {
+	// At least one of command or proxy is required.
+	if s.Command == "" && s.Proxy == "" {
+		errs = append(errs, fmt.Errorf("%s: command or proxy is required", svcPrefix))
+	}
+
+	// Proxy URL (validated only when set).
+	if s.Proxy != "" {
 		u, err := url.Parse(s.Proxy)
 		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 			errs = append(errs, fmt.Errorf("%s.proxy %q must be a valid URL with http or https scheme", svcPrefix, s.Proxy))
 		}
 	}
 
-	// Subdomain (optional)
+	// Route and subdomain require proxy.
+	if s.Route != "" && s.Proxy == "" {
+		errs = append(errs, fmt.Errorf("%s.route requires proxy to be set", svcPrefix))
+	}
+	if s.Subdomain != "" && s.Proxy == "" {
+		errs = append(errs, fmt.Errorf("%s.subdomain requires proxy to be set", svcPrefix))
+	}
+
+	// Subdomain format (optional).
 	if s.Subdomain != "" && !validHostnameLabel.MatchString(s.Subdomain) {
 		errs = append(errs, fmt.Errorf("%s.subdomain %q must be a valid hostname label", svcPrefix, s.Subdomain))
+	}
+
+	// EnvFile must be a relative path without traversal.
+	if s.EnvFile != "" {
+		if filepath.IsAbs(s.EnvFile) {
+			errs = append(errs, fmt.Errorf("%s.env_file must be a relative path, got %q", svcPrefix, s.EnvFile))
+		} else if strings.Contains(s.EnvFile, "..") {
+			errs = append(errs, fmt.Errorf("%s.env_file must not contain '..', got %q", svcPrefix, s.EnvFile))
+		}
 	}
 
 	return errs

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -153,7 +153,6 @@ func TestValidate_ServiceProxy(t *testing.T) {
 		proxy    string
 		errSubst string
 	}{
-		{"empty", "", "proxy is required"},
 		{"no scheme", "localhost:3000", "must be a valid URL"},
 		{"ftp scheme", "ftp://localhost:3000", "must be a valid URL"},
 	}
@@ -165,6 +164,56 @@ func TestValidate_ServiceProxy(t *testing.T) {
 			cfg.Projects["myapp"] = p
 			errs := Validate(cfg)
 			requireError(t, errs, tt.errSubst)
+		})
+	}
+}
+
+func TestValidate_ServiceCommandOrProxy(t *testing.T) {
+	tests := []struct {
+		name     string
+		svc      Service
+		wantErr  string
+	}{
+		{
+			name:    "neither command nor proxy",
+			svc:     Service{},
+			wantErr: "command or proxy is required",
+		},
+		{
+			name: "command only",
+			svc:  Service{Command: "php artisan queue:work"},
+		},
+		{
+			name: "proxy only",
+			svc:  Service{Proxy: "http://localhost:3000"},
+		},
+		{
+			name: "command and proxy",
+			svc:  Service{Command: "php artisan serve --port=8000", Proxy: "http://localhost:8000"},
+		},
+		{
+			name:    "route without proxy",
+			svc:     Service{Command: "echo hello", Route: "/api/*"},
+			wantErr: "route requires proxy",
+		},
+		{
+			name:    "subdomain without proxy",
+			svc:     Service{Command: "echo hello", Subdomain: "api"},
+			wantErr: "subdomain requires proxy",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			p := cfg.Projects["myapp"]
+			p.Services = map[string]Service{"web": tt.svc}
+			cfg.Projects["myapp"] = p
+			errs := Validate(cfg)
+			if tt.wantErr != "" {
+				requireError(t, errs, tt.wantErr)
+			} else if len(errs) != 0 {
+				t.Errorf("expected no errors, got %v", errs)
+			}
 		})
 	}
 }
@@ -194,6 +243,34 @@ func TestValidate_NoProjects(t *testing.T) {
 	errs := Validate(cfg)
 	if len(errs) != 0 {
 		t.Fatalf("config with no projects should be valid, got %v", errs)
+	}
+}
+
+func TestValidate_ServiceEnvFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		envFile string
+		wantErr string
+	}{
+		{"relative path", ".env", ""},
+		{"nested relative", "config/.env", ""},
+		{"absolute path", "/etc/secrets/.env", "must be a relative path"},
+		{"parent traversal", "../.env", "must not contain '..'"},
+		{"nested traversal", "config/../../.env", "must not contain '..'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			p := cfg.Projects["myapp"]
+			p.Services = map[string]Service{"web": {Command: "npm start", EnvFile: tt.envFile}}
+			cfg.Projects["myapp"] = p
+			errs := Validate(cfg)
+			if tt.wantErr != "" {
+				requireError(t, errs, tt.wantErr)
+			} else if len(errs) != 0 {
+				t.Errorf("expected no errors, got %v", errs)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/dns"
 	"github.com/httphatch/hatch/internal/health"
+	"github.com/httphatch/hatch/internal/process"
 )
 
 // Daemon orchestrates all Hatch subsystems as a long-running background process.
@@ -24,6 +25,7 @@ type Daemon struct {
 	caddy     *caddy.Server
 	dns       *dns.Server
 	health    *health.Checker
+	processes *process.Manager
 	watcher   *config.Watcher
 	api       *api.Server
 	pidFile   *os.File
@@ -142,10 +144,28 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.health = checker
 	log.Info().Msg("health checker started")
 
+	// Start process manager.
+	procMgr := process.NewManager(process.ManagerConfig{
+		OnOutput: func(project, service, source, line string) {
+			log.Info().
+				Str("project", project).
+				Str("service", service).
+				Str("source", source).
+				Msg(line)
+		},
+	})
+	if err := procMgr.ApplyConfig(cfg); err != nil {
+		d.shutdownPartial()
+		return fmt.Errorf("apply process config: %w", err)
+	}
+	d.processes = procMgr
+	log.Info().Msg("process manager started")
+
 	// Start API server.
 	apiSrv := api.NewServer(api.ServerConfig{
 		Addr:      "127.0.0.1:42824",
 		Health:    d.health,
+		Processes: d.processes,
 		Daemon:    d,
 		CAPaths:   d.caPaths,
 		Version:   d.version,
@@ -211,6 +231,14 @@ func (d *Daemon) Shutdown() error {
 		log.Info().Msg("config watcher stopped")
 	}
 
+	// Process manager.
+	if d.processes != nil {
+		if err := d.processes.Stop(); err != nil {
+			errs = append(errs, fmt.Errorf("stop process manager: %w", err))
+		}
+		log.Info().Msg("process manager stopped")
+	}
+
 	// Health checker.
 	if d.health != nil {
 		if err := d.health.Stop(); err != nil {
@@ -274,6 +302,13 @@ func (d *Daemon) onConfigReload(cfg config.Config) {
 	}
 
 	d.health.UpdateConfig(cfg)
+
+	if d.processes != nil {
+		if err := d.processes.ApplyConfig(cfg); err != nil {
+			log.Error().Err(err).Msg("failed to apply process config")
+		}
+	}
+
 	log.Info().Msg("config reloaded successfully")
 }
 
@@ -293,6 +328,9 @@ func (d *Daemon) shutdownPartial() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = d.api.Shutdown(ctx)
 		cancel()
+	}
+	if d.processes != nil {
+		_ = d.processes.Stop()
 	}
 	if d.health != nil {
 		_ = d.health.Stop()

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -213,6 +213,9 @@ func (c *Checker) applyConfig(appCfg config.Config) {
 			continue
 		}
 		for svcName, svc := range proj.Services {
+			if svc.Proxy == "" {
+				continue
+			}
 			key := ServiceKey{Project: projName, Service: svcName}
 			newTargets[key] = extractDialAddress(svc.Proxy)
 		}

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -315,6 +315,39 @@ func TestChecker_DisabledProjectSkipped(t *testing.T) {
 	}
 }
 
+func TestChecker_CommandOnlyServiceSkipped(t *testing.T) {
+	ln := startTestListener(t)
+
+	cfg := config.Config{
+		Projects: map[string]config.Project{
+			"myproject": {
+				Enabled: true,
+				Services: map[string]config.Service{
+					"web":    {Proxy: "http://" + ln.Addr().String()},
+					"worker": {Command: "php artisan queue:work"},
+				},
+			},
+		},
+	}
+
+	c := newTestChecker()
+	if err := c.Start(cfg); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Stop() }()
+
+	waitForStatus(t, c, testKey, StatusHealthy, 2*time.Second)
+
+	all := c.ServiceStatuses()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 target (command-only skipped), got %d", len(all))
+	}
+	workerKey := ServiceKey{Project: "myproject", Service: "worker"}
+	if _, ok := all[workerKey]; ok {
+		t.Fatal("command-only service should not be tracked by health checker")
+	}
+}
+
 func TestExtractDialAddress(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/process/env.go
+++ b/internal/process/env.go
@@ -1,0 +1,76 @@
+package process
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LoadEnvFile reads a .env file and returns a map of key-value pairs.
+// It supports comments (#), empty lines, quoted values (single and double),
+// and inline comments after unquoted values.
+func LoadEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open env file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	env := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, err := parseEnvLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNum, err)
+		}
+
+		env[key] = value
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read env file: %w", err)
+	}
+
+	return env, nil
+}
+
+func parseEnvLine(line string) (string, string, error) {
+	// Split on first '='.
+	idx := strings.IndexByte(line, '=')
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid line: no '=' found")
+	}
+
+	key := strings.TrimSpace(line[:idx])
+	if key == "" {
+		return "", "", fmt.Errorf("invalid line: empty key")
+	}
+
+	raw := strings.TrimSpace(line[idx+1:])
+
+	// Handle quoted values.
+	if len(raw) >= 2 {
+		if (raw[0] == '"' && raw[len(raw)-1] == '"') ||
+			(raw[0] == '\'' && raw[len(raw)-1] == '\'') {
+			return key, raw[1 : len(raw)-1], nil
+		}
+	}
+
+	// Strip inline comment for unquoted values.
+	if ci := strings.IndexByte(raw, '#'); ci >= 0 {
+		raw = strings.TrimSpace(raw[:ci])
+	}
+
+	return key, raw, nil
+}

--- a/internal/process/env_test.go
+++ b/internal/process/env_test.go
@@ -1,0 +1,110 @@
+package process
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeEnvFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadEnvFile_Basic(t *testing.T) {
+	path := writeEnvFile(t, "FOO=bar\nBAZ=qux\n")
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "bar")
+	}
+	if env["BAZ"] != "qux" {
+		t.Errorf("BAZ = %q, want %q", env["BAZ"], "qux")
+	}
+}
+
+func TestLoadEnvFile_CommentsAndBlanks(t *testing.T) {
+	path := writeEnvFile(t, "# comment\n\nFOO=bar\n\n# another\nBAZ=qux\n")
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(env))
+	}
+}
+
+func TestLoadEnvFile_QuotedValues(t *testing.T) {
+	path := writeEnvFile(t, `FOO="hello world"
+BAR='single quoted'
+BAZ="has # hash"
+`)
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["FOO"] != "hello world" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "hello world")
+	}
+	if env["BAR"] != "single quoted" {
+		t.Errorf("BAR = %q, want %q", env["BAR"], "single quoted")
+	}
+	if env["BAZ"] != "has # hash" {
+		t.Errorf("BAZ = %q, want %q", env["BAZ"], "has # hash")
+	}
+}
+
+func TestLoadEnvFile_InlineComment(t *testing.T) {
+	path := writeEnvFile(t, "FOO=bar # this is a comment\n")
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "bar")
+	}
+}
+
+func TestLoadEnvFile_Whitespace(t *testing.T) {
+	path := writeEnvFile(t, "  FOO  =  bar  \n")
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["FOO"] != "bar" {
+		t.Errorf("FOO = %q, want %q", env["FOO"], "bar")
+	}
+}
+
+func TestLoadEnvFile_EmptyValue(t *testing.T) {
+	path := writeEnvFile(t, "FOO=\n")
+	env, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if env["FOO"] != "" {
+		t.Errorf("FOO = %q, want empty", env["FOO"])
+	}
+}
+
+func TestLoadEnvFile_NoEquals(t *testing.T) {
+	path := writeEnvFile(t, "INVALID_LINE\n")
+	_, err := LoadEnvFile(path)
+	if err == nil {
+		t.Fatal("expected error for line without '='")
+	}
+}
+
+func TestLoadEnvFile_Missing(t *testing.T) {
+	_, err := LoadEnvFile("/nonexistent/.env")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -1,0 +1,328 @@
+package process
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/httphatch/hatch/internal/config"
+)
+
+const (
+	minBackoff       = 1 * time.Second
+	maxBackoff       = 30 * time.Second
+	backoffResetTime = 60 * time.Second
+)
+
+// ServiceID uniquely identifies a managed process.
+type ServiceID struct {
+	Project string
+	Service string
+}
+
+func (id ServiceID) String() string {
+	return id.Project + "/" + id.Service
+}
+
+// ProcessStatus holds the current state of a managed process.
+type ProcessStatus struct {
+	Command  string    `json:"command"`
+	Running  bool      `json:"running"`
+	Restarts int       `json:"restarts"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// ManagerConfig holds the configuration for a process Manager.
+type ManagerConfig struct {
+	OnOutput func(project, service, source, line string)
+}
+
+// supervised holds the state for a single supervised process.
+type supervised struct {
+	id      ServiceID
+	command string
+	dir     string
+	env     []string
+	runner  *Runner
+	cancel  context.CancelFunc
+	done    chan struct{} // closed when supervision goroutine exits
+
+	mu       sync.Mutex
+	restarts int
+	started  time.Time
+}
+
+// Manager supervises processes defined in the Hatch config.
+type Manager struct {
+	cfg       ManagerConfig
+	mu        sync.Mutex
+	processes map[ServiceID]*supervised
+}
+
+// NewManager creates a new process Manager.
+func NewManager(cfg ManagerConfig) *Manager {
+	return &Manager{
+		cfg:       cfg,
+		processes: make(map[ServiceID]*supervised),
+	}
+}
+
+// ApplyConfig reconciles running processes with the given config.
+// It starts new processes, stops removed ones, and restarts changed ones.
+func (m *Manager) ApplyConfig(appCfg config.Config) error {
+	desired := m.buildDesired(appCfg)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Stop processes no longer in config.
+	for id, sup := range m.processes {
+		if _, ok := desired[id]; !ok {
+			sup.cancel()
+			<-sup.done
+			delete(m.processes, id)
+		}
+	}
+
+	// Start or restart processes.
+	for id, want := range desired {
+		if existing, ok := m.processes[id]; ok {
+			// Check if config changed.
+			if existing.command == want.command && existing.dir == want.dir && envEqual(existing.env, want.env) {
+				continue
+			}
+			// Restart: stop old, start new.
+			existing.cancel()
+			<-existing.done
+			delete(m.processes, id)
+		}
+
+		sup := m.startSupervised(id, want.command, want.dir, want.env)
+		m.processes[id] = sup
+	}
+
+	return nil
+}
+
+// Stop terminates all managed processes.
+func (m *Manager) Stop() error {
+	m.mu.Lock()
+	procs := make(map[ServiceID]*supervised, len(m.processes))
+	for k, v := range m.processes {
+		procs[k] = v
+	}
+	m.mu.Unlock()
+
+	for _, sup := range procs {
+		sup.cancel()
+		<-sup.done
+	}
+
+	m.mu.Lock()
+	m.processes = make(map[ServiceID]*supervised)
+	m.mu.Unlock()
+
+	return nil
+}
+
+// Statuses returns a snapshot of all managed process statuses.
+func (m *Manager) Statuses() map[ServiceID]ProcessStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make(map[ServiceID]ProcessStatus, len(m.processes))
+	for id, sup := range m.processes {
+		sup.mu.Lock()
+		running := false
+		if sup.runner != nil {
+			select {
+			case <-sup.runner.Done():
+			default:
+				running = true
+			}
+		}
+		out[id] = ProcessStatus{
+			Command:   sup.command,
+			Running:   running,
+			Restarts:  sup.restarts,
+			StartedAt: sup.started,
+		}
+		sup.mu.Unlock()
+	}
+	return out
+}
+
+type desiredProcess struct {
+	command string
+	dir     string
+	env     []string
+}
+
+func (m *Manager) buildDesired(appCfg config.Config) map[ServiceID]desiredProcess {
+	desired := make(map[ServiceID]desiredProcess)
+	for projName, proj := range appCfg.Projects {
+		if !proj.Enabled {
+			continue
+		}
+		for svcName, svc := range proj.Services {
+			if svc.Command == "" {
+				continue
+			}
+
+			id := ServiceID{Project: projName, Service: svcName}
+			env := os.Environ()
+
+			// Load env file if specified.
+			if svc.EnvFile != "" {
+				envFilePath := svc.EnvFile
+				if !filepath.IsAbs(envFilePath) && proj.Path != "" {
+					envFilePath = filepath.Join(proj.Path, envFilePath)
+				}
+				envFilePath = filepath.Clean(envFilePath)
+
+				// Block path traversal outside the project directory.
+				if proj.Path != "" && !strings.HasPrefix(envFilePath, filepath.Clean(proj.Path)+string(filepath.Separator)) {
+					log.Warn().
+						Str("project", projName).
+						Str("service", svcName).
+						Str("env_file", svc.EnvFile).
+						Msg("env_file path escapes project directory, skipping")
+				} else if fileEnv, err := LoadEnvFile(envFilePath); err == nil {
+					for k, v := range fileEnv {
+						env = append(env, k+"="+v)
+					}
+				} else {
+					log.Warn().Err(err).
+						Str("project", projName).
+						Str("service", svcName).
+						Str("env_file", envFilePath).
+						Msg("failed to load env file")
+				}
+			}
+
+			desired[id] = desiredProcess{
+				command: svc.Command,
+				dir:     proj.Path,
+				env:     env,
+			}
+		}
+	}
+	return desired
+}
+
+func (m *Manager) startSupervised(id ServiceID, command, dir string, env []string) *supervised {
+	ctx, cancel := context.WithCancel(context.Background())
+	sup := &supervised{
+		id:      id,
+		command: command,
+		dir:     dir,
+		env:     env,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		started: time.Now(),
+	}
+
+	go m.supervise(ctx, sup)
+
+	return sup
+}
+
+func (m *Manager) supervise(ctx context.Context, sup *supervised) {
+	defer close(sup.done)
+
+	backoff := minBackoff
+
+	for {
+		runner := &Runner{cfg: RunnerConfig{
+			Name:    sup.id.String(),
+			Command: sup.command,
+			Dir:     sup.dir,
+			Env:     sup.env,
+			OnOutput: func(name, source, line string) {
+				if m.cfg.OnOutput != nil {
+					m.cfg.OnOutput(sup.id.Project, sup.id.Service, source, line)
+				}
+			},
+		}}
+
+		sup.mu.Lock()
+		sup.runner = runner
+		sup.mu.Unlock()
+
+		if err := runner.Start(ctx); err != nil {
+			// If context was cancelled, exit supervision.
+			if ctx.Err() != nil {
+				return
+			}
+			// Wait before retrying on start failure.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+				backoff = nextBackoff(backoff)
+				continue
+			}
+		}
+
+		startedAt := time.Now()
+
+		// Wait for exit or cancellation.
+		select {
+		case <-ctx.Done():
+			_ = runner.Stop()
+			return
+		case <-runner.Done():
+		}
+
+		// Don't restart if context is cancelled.
+		if ctx.Err() != nil {
+			return
+		}
+
+		// Reset backoff if the process ran long enough.
+		if time.Since(startedAt) >= backoffResetTime {
+			backoff = minBackoff
+		}
+
+		sup.mu.Lock()
+		sup.restarts++
+		sup.mu.Unlock()
+
+		// Wait before restarting.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+			backoff = nextBackoff(backoff)
+		}
+	}
+}
+
+func nextBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > maxBackoff {
+		return maxBackoff
+	}
+	return next
+}
+
+func envEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]bool, len(a))
+	for _, v := range a {
+		set[v] = true
+	}
+	for _, v := range b {
+		if !set[v] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/process/manager_test.go
+++ b/internal/process/manager_test.go
@@ -1,0 +1,258 @@
+package process
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/httphatch/hatch/internal/config"
+)
+
+func testAppConfig(command string) config.Config {
+	return config.Config{
+		Projects: map[string]config.Project{
+			"myapp": {
+				Path:    "/tmp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"worker": {Command: command},
+				},
+			},
+		},
+	}
+}
+
+// waitForRunning polls until the given service is running or deadline expires.
+func waitForRunning(t *testing.T, mgr *Manager, id ServiceID, deadline time.Duration) {
+	t.Helper()
+	dl := time.After(deadline)
+	for {
+		st, ok := mgr.Statuses()[id]
+		if ok && st.Running {
+			return
+		}
+		select {
+		case <-dl:
+			t.Fatalf("timed out waiting for %v to be running", id)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestManager_StartStop(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+
+	st := mgr.Statuses()[id]
+	if st.Command != "sleep 60" {
+		t.Errorf("command = %q, want %q", st.Command, "sleep 60")
+	}
+
+	if err := mgr.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	after := mgr.Statuses()
+	if len(after) != 0 {
+		t.Errorf("expected no processes after stop, got %d", len(after))
+	}
+}
+
+func TestManager_SkipsDisabledProjects(t *testing.T) {
+	cfg := config.Config{
+		Projects: map[string]config.Project{
+			"myapp": {
+				Path:    "/tmp",
+				Enabled: false,
+				Services: map[string]config.Service{
+					"worker": {Command: "sleep 60"},
+				},
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{})
+	if err := mgr.ApplyConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop() }()
+
+	if len(mgr.Statuses()) != 0 {
+		t.Error("expected no processes for disabled project")
+	}
+}
+
+func TestManager_SkipsProxyOnlyServices(t *testing.T) {
+	cfg := config.Config{
+		Projects: map[string]config.Project{
+			"myapp": {
+				Path:    "/tmp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"web": {Proxy: "http://localhost:3000"},
+				},
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{})
+	if err := mgr.ApplyConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Stop() }()
+
+	if len(mgr.Statuses()) != 0 {
+		t.Error("expected no managed processes for proxy-only service")
+	}
+}
+
+func TestManager_ApplyConfigRemovesOld(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	if _, ok := mgr.Statuses()[id]; !ok {
+		t.Fatal("expected worker to be running")
+	}
+
+	// Apply empty config — should remove the process.
+	if err := mgr.ApplyConfig(config.Config{Projects: map[string]config.Project{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(mgr.Statuses()) != 0 {
+		t.Error("expected no processes after removing from config")
+	}
+}
+
+func TestManager_ApplyConfigRestartsChanged(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st1 := mgr.Statuses()[id]
+
+	// Change command — should restart.
+	if err := mgr.ApplyConfig(testAppConfig("sleep 120")); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st2 := mgr.Statuses()[id]
+	if st2.Command != "sleep 120" {
+		t.Errorf("command = %q, want %q", st2.Command, "sleep 120")
+	}
+	if !st2.StartedAt.After(st1.StartedAt) && st2.StartedAt != st1.StartedAt {
+		t.Error("expected new start time after restart")
+	}
+}
+
+func TestManager_OutputCallback(t *testing.T) {
+	var mu sync.Mutex
+	var output []string
+
+	mgr := NewManager(ManagerConfig{
+		OnOutput: func(project, service, source, line string) {
+			mu.Lock()
+			output = append(output, project+"/"+service+":"+source+":"+line)
+			mu.Unlock()
+		},
+	})
+
+	if err := mgr.ApplyConfig(testAppConfig("echo hello")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the output to be captured.
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		n := len(output)
+		mu.Unlock()
+		if n > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for output")
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	if err := mgr.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(output) == 0 {
+		t.Fatal("expected output callback to be called")
+	}
+}
+
+func TestManager_ProcessRestartsOnCrash(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	// Use a command that exits immediately so it triggers a restart.
+	if err := mgr.ApplyConfig(testAppConfig("exit 1")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+
+	// Wait for at least one restart.
+	deadline := time.After(10 * time.Second)
+	for {
+		st, ok := mgr.Statuses()[id]
+		if ok && st.Restarts >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for restart")
+		default:
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+func TestManager_NoopForUnchanged(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	cfg := testAppConfig("sleep 60")
+	if err := mgr.ApplyConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st1 := mgr.Statuses()[id]
+
+	// Apply same config again — should be a no-op.
+	if err := mgr.ApplyConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	st2 := mgr.Statuses()[id]
+	if st2.StartedAt != st1.StartedAt {
+		t.Error("expected start time to remain the same for unchanged config")
+	}
+}

--- a/internal/process/runner.go
+++ b/internal/process/runner.go
@@ -1,0 +1,144 @@
+package process
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	stopTimeout = 5 * time.Second
+)
+
+// RunnerConfig holds the configuration for a single managed process.
+type RunnerConfig struct {
+	Name     string
+	Command  string
+	Dir      string
+	Env      []string
+	OnOutput func(name, source, line string)
+}
+
+// Runner manages the lifecycle of a single child process.
+type Runner struct {
+	cfg  RunnerConfig
+	cmd  *exec.Cmd
+	done chan struct{}
+	err  error
+	mu   sync.Mutex
+}
+
+// Start launches the process. The context is used only for cancellation
+// signalling — the process is stopped via Stop(), not context cancellation.
+func (r *Runner) Start(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", r.cfg.Command)
+	cmd.Dir = r.cfg.Dir
+	cmd.Env = r.cfg.Env
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start process: %w", err)
+	}
+
+	r.cmd = cmd
+	r.done = make(chan struct{})
+
+	// Scan output in background goroutines.
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		s := bufio.NewScanner(stdout)
+		for s.Scan() {
+			if r.cfg.OnOutput != nil {
+				r.cfg.OnOutput(r.cfg.Name, "stdout", s.Text())
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			if r.cfg.OnOutput != nil {
+				r.cfg.OnOutput(r.cfg.Name, "stderr", s.Text())
+			}
+		}
+	}()
+
+	// Wait for process exit in background.
+	go func() {
+		wg.Wait()
+		r.mu.Lock()
+		r.err = cmd.Wait()
+		r.mu.Unlock()
+		close(r.done)
+	}()
+
+	return nil
+}
+
+// Stop sends SIGTERM to the process group, waits up to 5 seconds,
+// then sends SIGKILL if still running.
+func (r *Runner) Stop() error {
+	r.mu.Lock()
+	cmd := r.cmd
+	done := r.done
+	r.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil || done == nil {
+		return nil
+	}
+
+	// Send SIGTERM to the process group.
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		// Process already exited.
+		return nil
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+
+	// Wait for graceful exit or timeout.
+	select {
+	case <-done:
+		return nil
+	case <-time.After(stopTimeout):
+	}
+
+	// Force kill.
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	<-done
+	return nil
+}
+
+// Done returns a channel that is closed when the process exits.
+func (r *Runner) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+// ExitErr returns the process exit error, or nil if it exited successfully.
+// Only valid after Done() is closed.
+func (r *Runner) ExitErr() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}

--- a/internal/process/runner_test.go
+++ b/internal/process/runner_test.go
@@ -1,0 +1,161 @@
+package process
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRunner_BasicExecution(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+
+	r := &Runner{cfg: RunnerConfig{
+		Name:    "test",
+		Command: "echo hello",
+		OnOutput: func(name, source, line string) {
+			mu.Lock()
+			lines = append(lines, line)
+			mu.Unlock()
+		},
+	}}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit in time")
+	}
+
+	if err := r.ExitErr(); err != nil {
+		t.Fatalf("unexpected exit error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lines) != 1 || lines[0] != "hello" {
+		t.Errorf("expected [hello], got %v", lines)
+	}
+}
+
+func TestRunner_StderrCapture(t *testing.T) {
+	var mu sync.Mutex
+	var sources []string
+
+	r := &Runner{cfg: RunnerConfig{
+		Name:    "test",
+		Command: "echo out; echo err >&2",
+		OnOutput: func(name, source, line string) {
+			mu.Lock()
+			sources = append(sources, source+":"+line)
+			mu.Unlock()
+		},
+	}}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit in time")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var hasStdout, hasStderr bool
+	for _, s := range sources {
+		if strings.HasPrefix(s, "stdout:") {
+			hasStdout = true
+		}
+		if strings.HasPrefix(s, "stderr:") {
+			hasStderr = true
+		}
+	}
+	if !hasStdout || !hasStderr {
+		t.Errorf("expected both stdout and stderr, got %v", sources)
+	}
+}
+
+func TestRunner_Stop(t *testing.T) {
+	r := &Runner{cfg: RunnerConfig{
+		Name:    "test",
+		Command: "sleep 60",
+	}}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Stop(); err != nil {
+		t.Fatalf("stop error: %v", err)
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("process did not stop in time")
+	}
+}
+
+func TestRunner_ExitError(t *testing.T) {
+	r := &Runner{cfg: RunnerConfig{
+		Name:    "test",
+		Command: "exit 42",
+	}}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("process did not exit in time")
+	}
+
+	if err := r.ExitErr(); err == nil {
+		t.Fatal("expected exit error for non-zero exit code")
+	}
+}
+
+func TestRunner_WorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	var mu sync.Mutex
+	var lines []string
+
+	r := &Runner{cfg: RunnerConfig{
+		Name:    "test",
+		Command: "pwd",
+		Dir:     dir,
+		OnOutput: func(name, source, line string) {
+			mu.Lock()
+			lines = append(lines, line)
+			mu.Unlock()
+		},
+	}}
+
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(lines) == 0 || !strings.HasPrefix(lines[0], dir) {
+		t.Errorf("expected working dir %s, got %v", dir, lines)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #9. Adds process management so Hatch can start, supervise, and stop local dev services alongside HTTPS proxying.

- Services now support a `command` field (at least one of `command` or `proxy` required)
- New `internal/process` package with .env parser, process runner (SIGTERM/SIGKILL lifecycle), and supervisor with exponential backoff restarts
- Caddy translation and health checker skip command-only services
- Process manager wired into daemon startup, shutdown, and config reload
- New `GET /api/processes` endpoint for status reporting
- `env_file` field for loading environment variables, validated against path traversal

Example `.hatch.yml`:
```yaml
domain: myapp.test
services:
  web:
    command: php artisan serve --port=8000
    proxy: http://localhost:8000
  worker:
    command: php artisan queue:work
```

## Test plan

- [x] `go vet ./...` passes
- [x] `go test -count=1 ./...` passes (all packages)
- [x] `make build` succeeds
- [x] Code reviewer and security reviewer agents run — all critical/warning issues fixed
- [ ] Manual test: create project with command-only and command+proxy services, run `hatch up`, verify processes start, logs appear, proxying works