### PR TITLE
Merge tray GUI into daemon process

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,69 +1,28 @@
-//go:build darwin
-
 package cmd
 
 import (
 	"fmt"
-	"io/fs"
+	"net/http"
+	"time"
 
-	"github.com/httphatch/hatch/internal/app"
-	"github.com/httphatch/hatch/internal/tray"
 	"github.com/spf13/cobra"
-	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 var appCmd = &cobra.Command{
 	Use:   "app",
-	Short: "Launch the Hatch GUI",
+	Short: "Open the Hatch dashboard",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		a := app.NewApp()
-
-		frontendAssets, err := fs.Sub(embeddedAssets, "frontend/dist")
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Post("http://127.0.0.1:42824/api/dashboard/show", "application/json", nil)
 		if err != nil {
-			return fmt.Errorf("loading frontend assets: %w", err)
+			return fmt.Errorf("daemon not running — start with: hatch up")
 		}
-
-		wailsApp := application.New(application.Options{
-			Name: "Hatch",
-			Icon: appIconData,
-			Mac: application.MacOptions{
-				ActivationPolicy: application.ActivationPolicyAccessory,
-			},
-			Services: []application.Service{
-				application.NewService(a),
-			},
-			Assets: application.AssetOptions{
-				Handler: application.BundledAssetFileServer(frontendAssets),
-			},
-		})
-
-		window := wailsApp.Window.NewWithOptions(application.WebviewWindowOptions{
-			Title:     "Hatch",
-			Width:     1024,
-			Height:    768,
-			MinWidth:  800,
-			MinHeight: 600,
-			Hidden:    true,
-			Mac: application.MacWindow{
-				TitleBar: application.MacTitleBarHiddenInsetUnified,
-				InvisibleTitleBarHeight: 48,
-			},
-		})
-
-		mgr := tray.NewManager(tray.ManagerConfig{
-			Version: version,
-			App:     wailsApp,
-			Window:  window,
-			Icon:    appIconData,
-		})
-
-		wailsApp.OnShutdown(func() {
-			mgr.Stop()
-		})
-
-		mgr.Start()
-
-		return wailsApp.Run()
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to show dashboard (status %d)", resp.StatusCode)
+		}
+		fmt.Println("Dashboard opened.")
+		return nil
 	},
 }
 

--- a/cmd/assets.go
+++ b/cmd/assets.go
@@ -2,8 +2,8 @@ package cmd
 
 import "embed"
 
-var embeddedAssets embed.FS //nolint:unused // read by cmd/app.go (darwin-only)
-var appIconData []byte      //nolint:unused // read by cmd/app.go (darwin-only)
+var embeddedAssets embed.FS //nolint:unused // read by cmd/run_darwin.go
+var appIconData []byte      //nolint:unused // read by cmd/run_darwin.go
 
 // SetAssets stores the embedded frontend filesystem for use by the app command.
 func SetAssets(assets embed.FS) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -44,7 +44,7 @@ var runCmd = &cobra.Command{
 		defer func() { _ = w.Close() }()
 
 		d := daemon.New(version, logHub)
-		if err := d.Run(ctx); err != nil {
+		if err := runDaemon(ctx, d); err != nil {
 			log.Error().Err(err).Msg("daemon exited with error")
 			os.Exit(1)
 		}

--- a/cmd/run_darwin.go
+++ b/cmd/run_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/httphatch/hatch/internal/daemon"
+)
+
+func runDaemon(ctx context.Context, d *daemon.Daemon) error {
+	return daemon.RunWithUI(ctx, d, embeddedAssets, appIconData)
+}

--- a/cmd/run_other.go
+++ b/cmd/run_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/httphatch/hatch/internal/daemon"
+)
+
+func runDaemon(ctx context.Context, d *daemon.Daemon) error {
+	return d.Run(ctx)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -358,6 +358,15 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "reloaded"})
 }
 
+func (s *Server) handleShowDashboard(w http.ResponseWriter, r *http.Request) {
+	if s.dashboard == nil {
+		writeError(w, http.StatusNotImplemented, "dashboard not available on this platform")
+		return
+	}
+	s.dashboard.ShowDashboard()
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 func (s *Server) handleCerts(w http.ResponseWriter, r *http.Request) {
 	type certInfo struct {
 		Exists  bool   `json:"exists"`

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,11 @@ type DaemonControl interface {
 	ReloadConfig() error
 }
 
+// DashboardShower can show the GUI dashboard window.
+type DashboardShower interface {
+	ShowDashboard()
+}
+
 // ProcessStatuser provides a snapshot of managed process statuses.
 type ProcessStatuser interface {
 	Statuses() map[process.ServiceID]process.ProcessStatus
@@ -29,6 +34,7 @@ type ProcessStatuser interface {
 type Server struct {
 	httpSrv   *http.Server
 	daemon    DaemonControl
+	dashboard DashboardShower
 	health    *health.Checker
 	processes ProcessStatuser
 	caPaths   certs.CAPaths
@@ -44,6 +50,7 @@ type ServerConfig struct {
 	Health    *health.Checker
 	Processes ProcessStatuser
 	Daemon    DaemonControl
+	Dashboard DashboardShower
 	CAPaths   certs.CAPaths
 	Version   string
 	StartTime time.Time
@@ -54,6 +61,7 @@ type ServerConfig struct {
 func NewServer(cfg ServerConfig) *Server {
 	s := &Server{
 		daemon:    cfg.Daemon,
+		dashboard: cfg.Dashboard,
 		health:    cfg.Health,
 		processes: cfg.Processes,
 		caPaths:   cfg.CAPaths,
@@ -109,5 +117,6 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/config", s.handleGetConfig)
 	mux.HandleFunc("PUT /api/config", s.handlePutConfig)
 	mux.HandleFunc("GET /api/certs", s.handleCerts)
-	mux.HandleFunc("POST /api/restart", s.handleRestart)
+	mux.HandleFunc("POST /api/restart", requireJSON(s.handleRestart))
+	mux.HandleFunc("POST /api/dashboard/show", requireJSON(s.handleShowDashboard))
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -49,6 +49,12 @@ func New(version string, logHub *api.LogHub) *Daemon {
 // Run starts all subsystems and blocks until ctx is cancelled.
 // On context cancellation it performs a graceful shutdown.
 func (d *Daemon) Run(ctx context.Context) error {
+	return d.RunSubsystems(ctx, nil)
+}
+
+// RunSubsystems starts all daemon subsystems and blocks until ctx is cancelled.
+// An optional DashboardShower is passed to the API server for the dashboard/show endpoint.
+func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShower) error {
 	d.startTime = time.Now()
 
 	// Write PID file (acquires flock).
@@ -167,6 +173,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		Health:    d.health,
 		Processes: d.processes,
 		Daemon:    d,
+		Dashboard: dashboard,
 		CAPaths:   d.caPaths,
 		Version:   d.version,
 		StartTime: d.startTime,
@@ -199,6 +206,14 @@ func (d *Daemon) Run(ctx context.Context) error {
 	log.Info().Msg("shutdown signal received")
 
 	return d.Shutdown()
+}
+
+// HealthChecker returns the daemon's health checker instance.
+// It is safe to call from any goroutine; returns nil before subsystems start.
+func (d *Daemon) HealthChecker() *health.Checker {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.health
 }
 
 // Shutdown stops all subsystems in reverse start order and removes the PID file.

--- a/internal/daemon/ui_darwin.go
+++ b/internal/daemon/ui_darwin.go
@@ -1,0 +1,114 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+
+	"github.com/rs/zerolog/log"
+	"github.com/wailsapp/wails/v3/pkg/application"
+	"github.com/wailsapp/wails/v3/pkg/events"
+
+	"github.com/httphatch/hatch/internal/app"
+	"github.com/httphatch/hatch/internal/tray"
+)
+
+// RunWithUI starts the daemon subsystems and the Wails tray/window in a single process.
+// The Wails app runs on the main thread (macOS requirement); daemon subsystems run in a goroutine.
+func RunWithUI(parentCtx context.Context, d *Daemon, assets embed.FS, icon []byte) error {
+	// Derive a cancellable context so we can stop daemon subsystems when Wails quits.
+	ctx, cancel := context.WithCancel(parentCtx)
+	defer cancel()
+	a := app.NewApp()
+
+	frontendAssets, err := fs.Sub(assets, "frontend/dist")
+	if err != nil {
+		return fmt.Errorf("loading frontend assets: %w", err)
+	}
+
+	wailsApp := application.New(application.Options{
+		Name: "Hatch",
+		Icon: icon,
+		Mac: application.MacOptions{
+			ActivationPolicy: application.ActivationPolicyAccessory,
+		},
+		Services: []application.Service{
+			application.NewService(a),
+		},
+		Assets: application.AssetOptions{
+			Handler: application.BundledAssetFileServer(frontendAssets),
+		},
+	})
+
+	window := wailsApp.Window.NewWithOptions(application.WebviewWindowOptions{
+		Title:     "Hatch",
+		Width:     1024,
+		Height:    768,
+		MinWidth:  800,
+		MinHeight: 600,
+		Hidden:    true,
+		Mac: application.MacWindow{
+			TitleBar:                application.MacTitleBarHiddenInsetUnified,
+			InvisibleTitleBarHeight: 48,
+		},
+	})
+
+	// Create tray manager. The daemon is passed as DaemonControl which also
+	// provides HealthChecker(). The health checker may be nil initially (before
+	// subsystems finish starting) — the tray's refresh handles this gracefully.
+	mgr := tray.NewManager(tray.ManagerConfig{
+		Version: d.version,
+		App:     wailsApp,
+		Window:  window,
+		Icon:    icon,
+		Daemon:  d,
+	})
+
+	// Channel to communicate subsystem startup result.
+	subsystemErr := make(chan error, 1)
+
+	// Start daemon subsystems in a background goroutine.
+	go func() {
+		if err := d.RunSubsystems(ctx, mgr); err != nil {
+			log.Error().Err(err).Msg("daemon subsystems failed")
+			subsystemErr <- err
+		} else {
+			subsystemErr <- nil
+		}
+		// Subsystems stopped — quit Wails app.
+		wailsApp.Quit()
+	}()
+
+	// Start the tray manager once the Wails event loop is ready.
+	wailsApp.Event.OnApplicationEvent(events.Common.ApplicationStarted, func(_ *application.ApplicationEvent) {
+		mgr.Start()
+	})
+
+	wailsApp.OnShutdown(func() {
+		mgr.Stop()
+		cancel() // Stop daemon subsystems when Wails quits.
+	})
+
+	// wailsApp.Run() blocks on the main thread.
+	if err := wailsApp.Run(); err != nil {
+		select {
+		case subErr := <-subsystemErr:
+			if subErr != nil {
+				return subErr
+			}
+		default:
+		}
+		return fmt.Errorf("wails app: %w", err)
+	}
+
+	// Return subsystem error if any.
+	select {
+	case subErr := <-subsystemErr:
+		return subErr
+	default:
+		return nil
+	}
+}

--- a/internal/daemon/ui_other.go
+++ b/internal/daemon/ui_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package daemon
+
+import (
+	"context"
+	"embed"
+)
+
+// RunWithUI is a no-op on non-darwin platforms — it just runs the daemon directly.
+func RunWithUI(ctx context.Context, d *Daemon, _ embed.FS, _ []byte) error {
+	return d.Run(ctx)
+}

--- a/internal/tray/manager.go
+++ b/internal/tray/manager.go
@@ -6,11 +6,12 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
 	"sort"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/pkg/browser"
 	"github.com/rs/zerolog/log"
@@ -18,9 +19,14 @@ import (
 	"github.com/wailsapp/wails/v3/pkg/events"
 
 	"github.com/httphatch/hatch/internal/config"
-	"github.com/httphatch/hatch/internal/daemon"
 	"github.com/httphatch/hatch/internal/health"
 )
+
+// DaemonControl allows the tray to trigger daemon operations directly.
+type DaemonControl interface {
+	ReloadConfig() error
+	HealthChecker() *health.Checker
+}
 
 // ManagerConfig holds the dependencies for a Manager.
 type ManagerConfig struct {
@@ -28,6 +34,7 @@ type ManagerConfig struct {
 	App     *application.App
 	Window  *application.WebviewWindow
 	Icon    []byte
+	Daemon  DaemonControl
 }
 
 // Manager orchestrates the system tray icon, menu, and health polling.
@@ -37,9 +44,10 @@ type Manager struct {
 	window  *application.WebviewWindow
 	icon    []byte
 	tray    *application.SystemTray
-	checker *health.Checker
+	daemon  DaemonControl
 
 	mu   sync.Mutex
+	wg   sync.WaitGroup
 	done chan struct{}
 }
 
@@ -50,30 +58,14 @@ func NewManager(cfg ManagerConfig) *Manager {
 		app:     cfg.App,
 		window:  cfg.Window,
 		icon:    cfg.Icon,
+		daemon:  cfg.Daemon,
 	}
 }
 
-// Start initialises the tray icon and begins periodic health polling.
+// Start initialises the tray icon and begins periodic menu refresh.
 func (m *Manager) Start() {
 	m.tray = m.app.SystemTray.New()
 	m.tray.SetTemplateIcon(iconPNG)
-
-	cfg, err := config.Load()
-	if err != nil {
-		log.Warn().Err(err).Msg("tray: failed to load config")
-		cfg = config.DefaultConfig()
-	}
-
-	m.checker = health.NewChecker(health.CheckerConfig{
-		Interval: 5 * time.Second,
-		Timeout:  2 * time.Second,
-		OnChange: func(_ health.ServiceKey, _, _ health.Status) {
-			m.refresh()
-		},
-	})
-	if err := m.checker.Start(cfg); err != nil {
-		log.Warn().Err(err).Msg("tray: failed to start health checker")
-	}
 
 	// Hide window on close instead of destroying it — removes the
 	// Dock icon but keeps the tray icon running.
@@ -85,17 +77,20 @@ func (m *Manager) Start() {
 	}
 
 	m.done = make(chan struct{})
+	done := m.done // capture for goroutine
 
 	// Initial refresh.
 	m.refresh()
 
 	// Periodic refresh goroutine.
+	m.wg.Add(1)
 	go func() {
+		defer m.wg.Done()
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
-			case <-m.done:
+			case <-done:
 				return
 			case <-ticker.C:
 				m.refresh()
@@ -104,17 +99,25 @@ func (m *Manager) Start() {
 	}()
 }
 
-// Stop tears down the health checker and removes the tray icon.
+// Stop tears down the tray icon. It is safe to call multiple times.
 func (m *Manager) Stop() {
-	if m.done != nil {
-		close(m.done)
-	}
-	if m.checker != nil {
-		_ = m.checker.Stop()
+	m.mu.Lock()
+	done := m.done
+	m.done = nil
+	m.mu.Unlock()
+
+	if done != nil {
+		close(done)
+		m.wg.Wait()
 	}
 	if m.tray != nil {
 		m.tray.Destroy()
 	}
+}
+
+// ShowDashboard shows the dashboard window (implements api.DashboardShower).
+func (m *Manager) ShowDashboard() {
+	m.showWindow()
 }
 
 // refresh reloads config, queries health, and rebuilds the menu.
@@ -128,15 +131,11 @@ func (m *Manager) refresh() {
 		cfg = config.DefaultConfig()
 	}
 
-	// Update the checker's targets in case config changed.
-	if m.checker != nil {
-		m.checker.UpdateConfig(cfg)
-	}
-
-	running, pid, _ := daemon.IsRunning()
 	statuses := make(map[health.ServiceKey]health.ServiceStatus)
-	if m.checker != nil {
-		statuses = m.checker.ServiceStatuses()
+	if m.daemon != nil {
+		if checker := m.daemon.HealthChecker(); checker != nil {
+			statuses = checker.ServiceStatuses()
+		}
 	}
 
 	// Build menu.
@@ -145,12 +144,8 @@ func (m *Manager) refresh() {
 	// Version header.
 	menu.Add(fmt.Sprintf("Hatch %s", m.version)).SetEnabled(false)
 
-	// Daemon status.
-	if running {
-		menu.Add(fmt.Sprintf("Daemon: Running (pid %d)", pid)).SetEnabled(false)
-	} else {
-		menu.Add("Daemon: Stopped").SetEnabled(false)
-	}
+	// Daemon status — always running since we are the daemon.
+	menu.Add("Daemon: Running").SetEnabled(false)
 
 	menu.AddSeparator()
 
@@ -182,25 +177,8 @@ func (m *Manager) refresh() {
 
 	menu.AddSeparator()
 
-	// Daemon control.
-	if running {
-		menu.Add("Stop Daemon").OnClick(func(_ *application.Context) {
-			go m.stopDaemon()
-		})
-	} else {
-		menu.Add("Start Daemon").OnClick(func(_ *application.Context) {
-			go m.startDaemon()
-		})
-	}
-
-	menu.Add("Restart Daemon").OnClick(func(_ *application.Context) {
-		go m.restartDaemon()
-	})
-
-	menu.AddSeparator()
-
-	// Quit.
-	menu.Add("Quit").OnClick(func(_ *application.Context) {
+	// Quit Hatch (triggers full daemon + tray shutdown).
+	menu.Add("Quit Hatch").OnClick(func(_ *application.Context) {
 		m.app.Quit()
 	})
 
@@ -315,43 +293,24 @@ func (m *Manager) toggleProject(name string, enabled bool) {
 		log.Warn().Err(err).Msg("tray: config save failed")
 		return
 	}
-	m.restartDaemon()
-}
-
-func (m *Manager) stopDaemon() {
-	m.runHatch("down")
-	time.Sleep(500 * time.Millisecond)
-	m.refresh()
-}
-
-func (m *Manager) startDaemon() {
-	m.runHatch("up")
-	time.Sleep(500 * time.Millisecond)
-	m.refresh()
-}
-
-func (m *Manager) restartDaemon() {
-	m.runHatch("restart")
-	time.Sleep(500 * time.Millisecond)
-	m.refresh()
-}
-
-func (m *Manager) runHatch(args ...string) {
-	exe, err := os.Executable()
-	if err != nil {
-		log.Warn().Err(err).Msg("tray: failed to find executable path")
-		return
+	if m.daemon != nil {
+		if err := m.daemon.ReloadConfig(); err != nil {
+			log.Warn().Err(err).Msg("tray: reload config failed")
+		}
 	}
-	cmd := exec.Command(exe, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		log.Warn().Err(err).Str("output", string(out)).Msgf("tray: hatch %s failed", args[0])
-	}
+	m.refresh()
 }
 
 // copyToClipboard writes text to the macOS pasteboard via pbcopy.
 func copyToClipboard(text string) {
+	safe := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, text)
 	cmd := exec.Command("pbcopy")
-	cmd.Stdin = bytes.NewReader([]byte(text))
+	cmd.Stdin = bytes.NewReader([]byte(safe))
 	if err := cmd.Run(); err != nil {
 		log.Warn().Err(err).Msg("tray: clipboard copy failed")
 	}


### PR DESCRIPTION
## Summary

Closes #7.

- Runs the Wails tray/window inside the daemon process instead of as a separate app. On macOS, `hatch _run` now hosts both daemon subsystems (in a goroutine) and the Wails event loop (on the main thread). On other platforms, behavior is unchanged.
- Repurposes `hatch app` from a standalone GUI to a lightweight HTTP client that tells the daemon to show the dashboard window via `POST /api/dashboard/show`.
- Refactors the tray `Manager` to use a `DaemonControl` interface (lazy health checker provider, direct `ReloadConfig()`) instead of spawning subprocesses and running its own health checker.
- Adds CSRF protection (`requireJSON`) to `POST /api/restart` and the new dashboard endpoint, HTTP client timeout, idempotent `Stop()` with `WaitGroup`, and clipboard input sanitization.

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] `make build` succeeds
- [ ] `hatch up` → tray icon appears, menu shows projects with health dots
- [ ] `hatch app` → dashboard window opens in the running daemon
- [ ] `hatch down` / `hatch restart` work as before
- [ ] Quit Hatch from tray menu cleanly shuts down daemon + tray
- [ ] `hatch update` restarts daemon with new binary (tray comes back)