### PR TITLE
Add tray_icon config toggle and fix settings dialog overflow

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,12 +22,13 @@ var runCmd = &cobra.Command{
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGTERM, syscall.SIGINT)
 		defer stop()
 
-		// Best-effort config load to read log level; default to "info".
-		logLevel := "info"
+		// Best-effort config load to read settings; use defaults on failure.
+		defaults := config.DefaultConfig()
+		logLevel := defaults.Settings.LogLevel
+		trayIcon := defaults.Settings.TrayIcon
 		if cfg, err := config.Load(); err == nil {
-			if cfg.Settings.LogLevel != "" {
-				logLevel = cfg.Settings.LogLevel
-			}
+			logLevel = cfg.Settings.LogLevel
+			trayIcon = cfg.Settings.TrayIcon
 		}
 
 		logHub := api.NewLogHub()
@@ -44,7 +45,7 @@ var runCmd = &cobra.Command{
 		defer func() { _ = w.Close() }()
 
 		d := daemon.New(version, logHub)
-		if err := runDaemon(ctx, d); err != nil {
+		if err := runDaemon(ctx, d, trayIcon); err != nil {
 			log.Error().Err(err).Msg("daemon exited with error")
 			os.Exit(1)
 		}

--- a/cmd/run_darwin.go
+++ b/cmd/run_darwin.go
@@ -8,6 +8,9 @@ import (
 	"github.com/httphatch/hatch/internal/daemon"
 )
 
-func runDaemon(ctx context.Context, d *daemon.Daemon) error {
-	return daemon.RunWithUI(ctx, d, embeddedAssets, appIconData)
+func runDaemon(ctx context.Context, d *daemon.Daemon, trayIcon bool) error {
+	if trayIcon {
+		return daemon.RunWithUI(ctx, d, embeddedAssets, appIconData)
+	}
+	return d.Run(ctx)
 }

--- a/cmd/run_other.go
+++ b/cmd/run_other.go
@@ -8,6 +8,6 @@ import (
 	"github.com/httphatch/hatch/internal/daemon"
 )
 
-func runDaemon(ctx context.Context, d *daemon.Daemon) error {
+func runDaemon(ctx context.Context, d *daemon.Daemon, _ bool) error {
 	return d.Run(ctx)
 }

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -13,6 +13,7 @@ settings:
   http_port: 80
   https_port: 443
   auto_start: true
+  tray_icon: true
   log_level: info
 projects:
   myapp:
@@ -80,6 +81,13 @@ Port for HTTPS traffic. Must be different from `http_port`.
 - **Default:** `true`
 
 When enabled, the daemon starts automatically on login via launchd and restarts on crash.
+
+### `settings.tray_icon`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Show the Hatch tray icon and status menu (macOS only). Set to `false` to run the daemon without a tray icon or window. Changes to this setting take effect after the daemon restarts.
 
 ### `settings.log_level`
 

--- a/frontend/src/components/settings-dialog.tsx
+++ b/frontend/src/components/settings-dialog.tsx
@@ -22,7 +22,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] flex flex-col">
         <DialogHeader>
           <DialogTitle className="text-muted-teal">Settings</DialogTitle>
         </DialogHeader>
@@ -50,7 +50,7 @@ export function SettingsDialog({ open, onOpenChange }: SettingsDialogProps) {
             Certificates
           </Button>
         </div>
-        <div className="min-h-[300px]">
+        <div className="min-h-[300px] overflow-y-auto flex-1">
           {tab === "config" && <ConfigEditor />}
           {tab === "certificates" && <CertStatus />}
         </div>

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -330,7 +330,7 @@ func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var cfg config.Config
+	cfg := config.DefaultConfig()
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid YAML: %s", err))
 		return

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -9,6 +9,7 @@ func DefaultConfig() Config {
 			HTTPPort:  80,
 			HTTPSPort: 443,
 			AutoStart: true,
+			TrayIcon:  true,
 			LogLevel:  "info",
 		},
 		Projects: make(map[string]Project),

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -16,7 +16,7 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("reading config: %w", err)
 	}
 
-	var cfg Config
+	cfg := DefaultConfig()
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		msgs := FormatYAMLError(err)
 		errs := make([]error, len(msgs))
@@ -117,13 +117,9 @@ func LoadRaw() (Config, error) {
 		return Config{}, fmt.Errorf("reading config: %w", err)
 	}
 
-	var cfg Config
+	cfg := DefaultConfig()
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return Config{}, fmt.Errorf("parsing config: %w", err)
-	}
-
-	if cfg.Projects == nil {
-		cfg.Projects = make(map[string]Project)
 	}
 
 	return cfg, nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -13,6 +13,7 @@ type Settings struct {
 	HTTPPort  int    `yaml:"http_port" json:"http_port"`
 	HTTPSPort int    `yaml:"https_port" json:"https_port"`
 	AutoStart bool   `yaml:"auto_start" json:"auto_start"`
+	TrayIcon  bool   `yaml:"tray_icon" json:"tray_icon"`
 	LogLevel  string `yaml:"log_level" json:"log_level"`
 }
 


### PR DESCRIPTION
## Summary

- Add `tray_icon` boolean setting (default `true`) that controls whether the macOS tray icon and status menu appear. When `false`, the daemon runs headless.
- Seed config structs from `DefaultConfig()` before YAML unmarshal in `Load`, `LoadRaw`, and `handlePutConfig` so missing bool fields inherit correct defaults instead of Go zero values.
- Cap the settings dialog at 90vh with a scrollable content area so the YAML editor no longer overflows the viewport.

Closes #16, closes #17

## Test plan

- [ ] `go test ./...` passes
- [ ] Set `tray_icon: false` in `~/.hatch/config.yml`, run `hatch down && hatch up`. Daemon runs without tray icon.
- [ ] Set `tray_icon: true` (or remove the key), restart. Tray icon appears.
- [ ] Open dashboard settings, add enough content to exceed viewport height. Content scrolls within the dialog.