### PR TITLE
Fix CORS for reverse proxy and remove wildcard CORS from API server

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -21,23 +21,6 @@ import (
 // maxBodySize is the maximum allowed request body (1 MB).
 const maxBodySize = 1 << 20
 
-// corsLocal wraps a handler to allow cross-origin requests from the Wails
-// webview (which uses a non-http scheme) to this localhost-only API.
-func corsLocal(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
-
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
@@ -50,7 +33,8 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // requireJSON rejects requests that don't have Content-Type: application/json.
 // This also serves as CSRF protection since non-simple content types trigger
-// a CORS preflight that the server does not respond to.
+// a CORS preflight that this server does not respond to (CORS is only handled
+// by the Caddy proxy layer for .test domains, not by the API server).
 func requireJSON(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ct := r.Header.Get("Content-Type")
@@ -361,6 +345,8 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePutConfig(w http.ResponseWriter, r *http.Request) {
+	// The non-simple Content-Type also serves as CSRF protection: it triggers
+	// a CORS preflight that this server does not respond to.
 	if ct := r.Header.Get("Content-Type"); ct != "application/yaml" {
 		writeError(w, http.StatusUnsupportedMediaType, "Content-Type must be application/yaml")
 		return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -78,7 +78,7 @@ func NewServer(cfg ServerConfig) *Server {
 
 	s.httpSrv = &http.Server{
 		Addr:              cfg.Addr,
-		Handler:           corsLocal(mux),
+		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}

--- a/internal/caddy/testdata/full.json
+++ b/internal/caddy/testdata/full.json
@@ -47,23 +47,89 @@
             {
               "handle": [
                 {
-                  "flush_interval": -1,
-                  "handler": "reverse_proxy",
-                  "headers": {
-                    "request": {
-                      "set": {
-                        "Connection": [
-                          "{http.request.header.Connection}"
-                        ],
-                        "Upgrade": [
-                          "{http.request.header.Upgrade}"
-                        ]
-                      }
-                    }
-                  },
-                  "upstreams": [
+                  "handler": "subroute",
+                  "routes": [
                     {
-                      "dial": "localhost:6001"
+                      "handle": [
+                        {
+                          "handler": "static_response",
+                          "headers": {
+                            "Access-Control-Allow-Credentials": [
+                              "true"
+                            ],
+                            "Access-Control-Allow-Headers": [
+                              "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                            ],
+                            "Access-Control-Allow-Methods": [
+                              "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                            ],
+                            "Access-Control-Allow-Origin": [
+                              "{http.request.header.Origin}"
+                            ],
+                            "Access-Control-Max-Age": [
+                              "3600"
+                            ],
+                            "Vary": [
+                              "Origin"
+                            ]
+                          },
+                          "status_code": "204"
+                        }
+                      ],
+                      "match": [
+                        {
+                          "method": [
+                            "OPTIONS"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "handle": [
+                        {
+                          "handler": "headers",
+                          "response": {
+                            "set": {
+                              "Access-Control-Allow-Credentials": [
+                                "true"
+                              ],
+                              "Access-Control-Allow-Headers": [
+                                "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                              ],
+                              "Access-Control-Allow-Methods": [
+                                "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                              ],
+                              "Access-Control-Allow-Origin": [
+                                "{http.request.header.Origin}"
+                              ],
+                              "Vary": [
+                                "Origin"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "flush_interval": -1,
+                          "handler": "reverse_proxy",
+                          "headers": {
+                            "request": {
+                              "set": {
+                                "Connection": [
+                                  "{http.request.header.Connection}"
+                                ],
+                                "Upgrade": [
+                                  "{http.request.header.Upgrade}"
+                                ]
+                              }
+                            }
+                          },
+                          "upstreams": [
+                            {
+                              "dial": "localhost:6001"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -80,10 +146,76 @@
             {
               "handle": [
                 {
-                  "handler": "reverse_proxy",
-                  "upstreams": [
+                  "handler": "subroute",
+                  "routes": [
                     {
-                      "dial": "localhost:8000"
+                      "handle": [
+                        {
+                          "handler": "static_response",
+                          "headers": {
+                            "Access-Control-Allow-Credentials": [
+                              "true"
+                            ],
+                            "Access-Control-Allow-Headers": [
+                              "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                            ],
+                            "Access-Control-Allow-Methods": [
+                              "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                            ],
+                            "Access-Control-Allow-Origin": [
+                              "{http.request.header.Origin}"
+                            ],
+                            "Access-Control-Max-Age": [
+                              "3600"
+                            ],
+                            "Vary": [
+                              "Origin"
+                            ]
+                          },
+                          "status_code": "204"
+                        }
+                      ],
+                      "match": [
+                        {
+                          "method": [
+                            "OPTIONS"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "handle": [
+                        {
+                          "handler": "headers",
+                          "response": {
+                            "set": {
+                              "Access-Control-Allow-Credentials": [
+                                "true"
+                              ],
+                              "Access-Control-Allow-Headers": [
+                                "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                              ],
+                              "Access-Control-Allow-Methods": [
+                                "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                              ],
+                              "Access-Control-Allow-Origin": [
+                                "{http.request.header.Origin}"
+                              ],
+                              "Vary": [
+                                "Origin"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "handler": "reverse_proxy",
+                          "upstreams": [
+                            {
+                              "dial": "localhost:8000"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -103,10 +235,76 @@
             {
               "handle": [
                 {
-                  "handler": "reverse_proxy",
-                  "upstreams": [
+                  "handler": "subroute",
+                  "routes": [
                     {
-                      "dial": "localhost:3000"
+                      "handle": [
+                        {
+                          "handler": "static_response",
+                          "headers": {
+                            "Access-Control-Allow-Credentials": [
+                              "true"
+                            ],
+                            "Access-Control-Allow-Headers": [
+                              "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                            ],
+                            "Access-Control-Allow-Methods": [
+                              "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                            ],
+                            "Access-Control-Allow-Origin": [
+                              "{http.request.header.Origin}"
+                            ],
+                            "Access-Control-Max-Age": [
+                              "3600"
+                            ],
+                            "Vary": [
+                              "Origin"
+                            ]
+                          },
+                          "status_code": "204"
+                        }
+                      ],
+                      "match": [
+                        {
+                          "method": [
+                            "OPTIONS"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "handle": [
+                        {
+                          "handler": "headers",
+                          "response": {
+                            "set": {
+                              "Access-Control-Allow-Credentials": [
+                                "true"
+                              ],
+                              "Access-Control-Allow-Headers": [
+                                "Authorization, Content-Type, X-Requested-With, Accept, Origin"
+                              ],
+                              "Access-Control-Allow-Methods": [
+                                "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+                              ],
+                              "Access-Control-Allow-Origin": [
+                                "{http.request.header.Origin}"
+                              ],
+                              "Vary": [
+                                "Origin"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "handler": "reverse_proxy",
+                          "upstreams": [
+                            {
+                              "dial": "localhost:3000"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }

--- a/internal/caddy/translate.go
+++ b/internal/caddy/translate.go
@@ -135,8 +135,21 @@ func routeTier(info routeInfo) int {
 	return 2
 }
 
+// corsHeaders returns the CORS response headers added to every proxied response.
+// The Origin is reflected from the request so that credentialed cross-origin
+// requests work between .test subdomains during local development.
+func corsHeaders() map[string][]string {
+	return map[string][]string{
+		"Access-Control-Allow-Origin":      {"{http.request.header.Origin}"},
+		"Access-Control-Allow-Methods":     {"GET, POST, PUT, PATCH, DELETE, OPTIONS"},
+		"Access-Control-Allow-Headers":     {"Authorization, Content-Type, X-Requested-With, Accept, Origin"},
+		"Access-Control-Allow-Credentials": {"true"},
+		"Vary":                             {"Origin"},
+	}
+}
+
 // buildRoute builds a single HTTPS route with host matcher, optional path matcher,
-// and reverse_proxy handler.
+// and a subroute that handles CORS preflight and adds CORS headers to responses.
 func buildRoute(domain string, svc config.Service) map[string]any {
 	match := map[string]any{
 		"host": []string{domain},
@@ -145,11 +158,49 @@ func buildRoute(domain string, svc config.Service) map[string]any {
 		match["path"] = []string{svc.Route}
 	}
 
-	handler := buildReverseProxyHandler(svc.Proxy, svc.WebSocket)
+	proxyHandler := buildReverseProxyHandler(svc.Proxy, svc.WebSocket)
+
+	cors := corsHeaders()
+
+	// Preflight headers include Max-Age to let browsers cache the result.
+	preflightHeaders := make(map[string][]string, len(cors)+1)
+	for k, v := range cors {
+		preflightHeaders[k] = v
+	}
+	preflightHeaders["Access-Control-Max-Age"] = []string{"3600"}
+
+	subroute := map[string]any{
+		"handler": "subroute",
+		"routes": []map[string]any{
+			{
+				"match": []map[string]any{
+					{"method": []string{"OPTIONS"}},
+				},
+				"handle": []map[string]any{
+					{
+						"handler":     "static_response",
+						"status_code": "204",
+						"headers":     preflightHeaders,
+					},
+				},
+			},
+			{
+				"handle": []map[string]any{
+					{
+						"handler": "headers",
+						"response": map[string]any{
+							"set": cors,
+						},
+					},
+					proxyHandler,
+				},
+			},
+		},
+	}
 
 	return map[string]any{
 		"match":    []map[string]any{match},
-		"handle":   []map[string]any{handler},
+		"handle":   []map[string]any{subroute},
 		"terminal": true,
 	}
 }

--- a/internal/caddy/translate_test.go
+++ b/internal/caddy/translate_test.go
@@ -71,11 +71,38 @@ func TestTranslate_SingleService(t *testing.T) {
 		t.Errorf("expected host myapp.test, got %s", hosts[0])
 	}
 
-	handler := route["handle"].([]map[string]any)[0]
-	if handler["handler"] != "reverse_proxy" {
-		t.Errorf("expected handler reverse_proxy, got %s", handler["handler"])
+	subroute := route["handle"].([]map[string]any)[0]
+	if subroute["handler"] != "subroute" {
+		t.Fatalf("expected handler subroute, got %s", subroute["handler"])
 	}
-	upstreams := handler["upstreams"].([]map[string]any)
+
+	subRoutes := subroute["routes"].([]map[string]any)
+	if len(subRoutes) != 2 {
+		t.Fatalf("expected 2 subroutes (preflight + proxy), got %d", len(subRoutes))
+	}
+
+	// First subroute: OPTIONS preflight.
+	preflightMatch := subRoutes[0]["match"].([]map[string]any)[0]
+	if methods := preflightMatch["method"].([]string); methods[0] != "OPTIONS" {
+		t.Errorf("expected preflight method OPTIONS, got %s", methods[0])
+	}
+	preflightHandler := subRoutes[0]["handle"].([]map[string]any)[0]
+	if preflightHandler["status_code"] != "204" {
+		t.Errorf("expected preflight status 204, got %v", preflightHandler["status_code"])
+	}
+
+	// Second subroute: headers + reverse_proxy.
+	proxyHandlers := subRoutes[1]["handle"].([]map[string]any)
+	if len(proxyHandlers) != 2 {
+		t.Fatalf("expected 2 handlers (headers + reverse_proxy), got %d", len(proxyHandlers))
+	}
+	if proxyHandlers[0]["handler"] != "headers" {
+		t.Errorf("expected headers handler, got %s", proxyHandlers[0]["handler"])
+	}
+	if proxyHandlers[1]["handler"] != "reverse_proxy" {
+		t.Errorf("expected reverse_proxy handler, got %s", proxyHandlers[1]["handler"])
+	}
+	upstreams := proxyHandlers[1]["upstreams"].([]map[string]any)
 	if upstreams[0]["dial"] != "localhost:3000" {
 		t.Errorf("expected dial localhost:3000, got %s", upstreams[0]["dial"])
 	}
@@ -186,7 +213,15 @@ func TestTranslate_WebSocket(t *testing.T) {
 		t.Fatalf("expected 1 route, got %d", len(routes))
 	}
 
-	handler := routes[0]["handle"].([]map[string]any)[0]
+	subroute := routes[0]["handle"].([]map[string]any)[0]
+	if subroute["handler"] != "subroute" {
+		t.Fatalf("expected subroute handler, got %s", subroute["handler"])
+	}
+
+	// The reverse_proxy handler is the second handler in the second subroute.
+	subRoutes := subroute["routes"].([]map[string]any)
+	proxyHandlers := subRoutes[1]["handle"].([]map[string]any)
+	handler := proxyHandlers[1]
 
 	flush, ok := handler["flush_interval"]
 	if !ok {


### PR DESCRIPTION
## Summary
- Add CORS headers to all Caddy proxy routes via subroute wrapping (OPTIONS preflight + response headers on all requests)
- Remove wildcard `Access-Control-Allow-Origin: *` from the API server since the Wails WebView calls the handler in-process
- Reflect request Origin with explicit allowed headers, credentials support, and `Vary: Origin`

## Test plan
- [x] `go test -race ./...` passes
- [x] `make build` succeeds
- [ ] `hatch stop && hatch up`, verify proxied responses include CORS headers in browser DevTools
- [ ] Test cross-subdomain fetch from browser console
- [ ] Verify dashboard still works (Wails WebView API calls)

Closes #14