### PR TITLE
Fix process cleanup race on daemon stop/restart

### DIFF
--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -77,16 +77,33 @@ func NewManager(cfg ManagerConfig) *Manager {
 func (m *Manager) ApplyConfig(appCfg config.Config) error {
 	desired := m.buildDesired(appCfg)
 
+	// Stop processes no longer in config. Release the lock before waiting
+	// so Statuses() and Stop() are not blocked during graceful shutdown.
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Stop processes no longer in config.
+	var removed []*supervised
+	var removedIDs []ServiceID
 	for id, sup := range m.processes {
 		if _, ok := desired[id]; !ok {
 			sup.cancel()
-			<-sup.done
-			delete(m.processes, id)
+			removed = append(removed, sup)
+			removedIDs = append(removedIDs, id)
 		}
+	}
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, sup := range removed {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-sup.done
+		}()
+	}
+	wg.Wait()
+
+	m.mu.Lock()
+	for _, id := range removedIDs {
+		delete(m.processes, id)
 	}
 
 	// Start or restart processes.
@@ -98,13 +115,16 @@ func (m *Manager) ApplyConfig(appCfg config.Config) error {
 			}
 			// Restart: stop old, start new.
 			existing.cancel()
+			m.mu.Unlock()
 			<-existing.done
+			m.mu.Lock()
 			delete(m.processes, id)
 		}
 
 		sup := m.startSupervised(id, want.command, want.dir, want.env)
 		m.processes[id] = sup
 	}
+	m.mu.Unlock()
 
 	return nil
 }
@@ -120,8 +140,16 @@ func (m *Manager) Stop() error {
 
 	for _, sup := range procs {
 		sup.cancel()
-		<-sup.done
 	}
+	var wg sync.WaitGroup
+	for _, sup := range procs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-sup.done
+		}()
+	}
+	wg.Wait()
 
 	m.mu.Lock()
 	m.processes = make(map[ServiceID]*supervised)
@@ -258,7 +286,7 @@ func (m *Manager) supervise(ctx context.Context, sup *supervised) {
 			},
 		}}
 
-		if err := runner.Start(ctx); err != nil {
+		if err := runner.Start(); err != nil {
 			sup.mu.Lock()
 			sup.runner = nil
 			sup.mu.Unlock()

--- a/internal/process/runner.go
+++ b/internal/process/runner.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,9 +32,9 @@ type Runner struct {
 	mu   sync.Mutex
 }
 
-// Start launches the process. The context is used only for cancellation
-// signalling — the process is stopped via Stop(), not context cancellation.
-func (r *Runner) Start(ctx context.Context) error {
+// Start launches the process. The process is stopped exclusively via Stop(),
+// which sends SIGTERM to the entire process group for clean shutdown.
+func (r *Runner) Start() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -43,7 +42,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	if shell == "" {
 		shell = "sh"
 	}
-	cmd := exec.CommandContext(ctx, shell, "-l", "-c", r.cfg.Command)
+	cmd := exec.Command(shell, "-l", "-c", r.cfg.Command)
 	cmd.Dir = r.cfg.Dir
 	cmd.Env = r.cfg.Env
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/internal/process/runner_test.go
+++ b/internal/process/runner_test.go
@@ -1,7 +1,6 @@
 package process
 
 import (
-	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -22,7 +21,7 @@ func TestRunner_BasicExecution(t *testing.T) {
 		},
 	}}
 
-	if err := r.Start(context.Background()); err != nil {
+	if err := r.Start(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -57,7 +56,7 @@ func TestRunner_StderrCapture(t *testing.T) {
 		},
 	}}
 
-	if err := r.Start(context.Background()); err != nil {
+	if err := r.Start(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -90,7 +89,7 @@ func TestRunner_Stop(t *testing.T) {
 		Command: "sleep 60",
 	}}
 
-	if err := r.Start(context.Background()); err != nil {
+	if err := r.Start(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,7 +110,7 @@ func TestRunner_ExitError(t *testing.T) {
 		Command: "exit 42",
 	}}
 
-	if err := r.Start(context.Background()); err != nil {
+	if err := r.Start(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +142,7 @@ func TestRunner_WorkingDirectory(t *testing.T) {
 		},
 	}}
 
-	if err := r.Start(context.Background()); err != nil {
+	if err := r.Start(); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Summary

- Replace `exec.CommandContext` with `exec.Command` in `Runner.Start()` to eliminate a race where context cancellation sends SIGKILL to only the shell PID, bypassing the process-group SIGTERM in `Stop()` and leaving child processes orphaned
- Make `Manager.Stop()` and `ApplyConfig()` shut down processes in parallel instead of sequentially
- Release the manager mutex before blocking on process exit so `Statuses()` is not stalled during shutdown

## Test plan

- [x] `go test -race ./internal/process/...` passes
- [x] `go test -race ./...` passes
- [x] `make build` succeeds
- [ ] Manual: `hatch down && hatch up`, start a project with a command that spawns child processes, run `hatch down`, verify no orphaned processes remain

Fixes #27