### PR TITLE
Add individual process stop/start/restart

### DIFF
--- a/cmd/process.go
+++ b/cmd/process.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+const daemonBaseURL = "http://127.0.0.1:42824"
+
+var processCmd = &cobra.Command{
+	Use:   "process",
+	Short: "Manage individual processes",
+}
+
+var processStopCmd = &cobra.Command{
+	Use:   "stop <project>/<service>",
+	Short: "Stop a managed process",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		project, service, err := parseProcessArg(args[0])
+		if err != nil {
+			return err
+		}
+		if err := postProcessAction(project, service, "stop"); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s/%s\n", color.New(color.FgRed, color.Bold).Sprint("Stopped"), project, service)
+		return nil
+	},
+}
+
+var processStartCmd = &cobra.Command{
+	Use:   "start <project>/<service>",
+	Short: "Start a stopped process",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		project, service, err := parseProcessArg(args[0])
+		if err != nil {
+			return err
+		}
+		if err := postProcessAction(project, service, "start"); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s/%s\n", color.New(color.FgGreen, color.Bold).Sprint("Started"), project, service)
+		return nil
+	},
+}
+
+var processRestartCmd = &cobra.Command{
+	Use:   "restart <project>/<service>",
+	Short: "Restart a managed process",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		project, service, err := parseProcessArg(args[0])
+		if err != nil {
+			return err
+		}
+		if err := postProcessAction(project, service, "restart"); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s/%s\n", color.New(color.FgCyan, color.Bold).Sprint("Restarted"), project, service)
+		return nil
+	},
+}
+
+func parseProcessArg(arg string) (project, service string, err error) {
+	project, service, ok := strings.Cut(arg, "/")
+	if !ok || project == "" || service == "" {
+		return "", "", fmt.Errorf("invalid format %q, expected <project>/<service>", arg)
+	}
+	return project, service, nil
+}
+
+func postProcessAction(project, service, action string) error {
+	endpoint := fmt.Sprintf("%s/api/processes/%s/%s/%s", daemonBaseURL, url.PathEscape(project), url.PathEscape(service), action)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(endpoint, "application/json", strings.NewReader("{}"))
+	if err != nil {
+		return fmt.Errorf("daemon not running, start with: hatch up")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to %s process (status %d)", action, resp.StatusCode)
+	}
+	return nil
+}
+
+func init() {
+	processCmd.AddCommand(processStopCmd)
+	processCmd.AddCommand(processStartCmd)
+	processCmd.AddCommand(processRestartCmd)
+	rootCmd.AddCommand(processCmd)
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
   const { projects, add, update, remove, toggle, loading, error } =
     useProjects();
   const { lookup } = useHealth();
-  const { lookup: processLookup } = useProcesses();
+  const { lookup: processLookup, refresh: refreshProcesses } = useProcesses();
   const { status } = useStatus();
 
   const [addOpen, setAddOpen] = useState(false);
@@ -57,6 +57,7 @@ function App() {
               onEdit={setEditTarget}
               onDelete={handleDelete}
               onAdd={() => setAddOpen(true)}
+              onProcessRefresh={refreshProcesses}
             />
             <RouteMap projects={projects} healthLookup={lookup} />
           </>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -92,6 +92,27 @@ export function getProcesses(): Promise<ProcessStatus[]> {
   return request("/api/processes");
 }
 
+export function stopProcess(project: string, service: string): Promise<void> {
+  return request(`/api/processes/${encodeURIComponent(project)}/${encodeURIComponent(service)}/stop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function startProcess(project: string, service: string): Promise<void> {
+  return request(`/api/processes/${encodeURIComponent(project)}/${encodeURIComponent(service)}/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function restartProcess(project: string, service: string): Promise<void> {
+  return request(`/api/processes/${encodeURIComponent(project)}/${encodeURIComponent(service)}/restart`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 export function getCerts(): Promise<CertStatus> {
   return request("/api/certs");
 }

--- a/frontend/src/components/project-card.tsx
+++ b/frontend/src/components/project-card.tsx
@@ -26,6 +26,7 @@ interface ProjectCardProps {
   onToggle: (name: string) => void;
   onEdit: (name: string) => void;
   onDelete: (name: string) => void;
+  onProcessRefresh: () => void;
 }
 
 export function ProjectCard({
@@ -36,6 +37,7 @@ export function ProjectCard({
   onToggle,
   onEdit,
   onDelete,
+  onProcessRefresh,
 }: ProjectCardProps) {
   const url = `https://${project.domain}`;
 
@@ -118,6 +120,7 @@ export function ProjectCard({
               domain={project.domain}
               process={processLookup(name, svcName)}
               projectName={name}
+              onRefresh={onProcessRefresh}
             />
           ))}
         </div>

--- a/frontend/src/components/project-list.tsx
+++ b/frontend/src/components/project-list.tsx
@@ -10,6 +10,7 @@ interface ProjectListProps {
   onEdit: (name: string) => void;
   onDelete: (name: string) => void;
   onAdd: () => void;
+  onProcessRefresh: () => void;
 }
 
 export function ProjectList({
@@ -20,6 +21,7 @@ export function ProjectList({
   onEdit,
   onDelete,
   onAdd,
+  onProcessRefresh,
 }: ProjectListProps) {
   const entries = Object.entries(projects);
 
@@ -39,6 +41,7 @@ export function ProjectList({
           onToggle={onToggle}
           onEdit={onEdit}
           onDelete={onDelete}
+          onProcessRefresh={onProcessRefresh}
         />
       ))}
     </div>

--- a/frontend/src/components/service-row.tsx
+++ b/frontend/src/components/service-row.tsx
@@ -9,8 +9,9 @@ import {
 import { HealthDot } from "@/components/health-dot";
 import { ProcessOutputDialog } from "@/components/process-output-dialog";
 import { serviceUrl } from "@/lib/service-url";
+import { stopProcess, startProcess, restartProcess } from "@/api";
 import type { ProcessStatus, Service, ServiceHealth } from "@/types";
-import { ExternalLink, Terminal } from "lucide-react";
+import { ExternalLink, Play, RotateCw, Square, Terminal } from "lucide-react";
 import { Browser } from "@wailsio/runtime";
 
 interface ServiceRowProps {
@@ -20,11 +21,25 @@ interface ServiceRowProps {
   domain: string;
   process?: ProcessStatus;
   projectName: string;
+  onRefresh: () => void;
 }
 
-export function ServiceRow({ name, service, health, domain, process, projectName }: ServiceRowProps) {
+export function ServiceRow({ name, service, health, domain, process, projectName, onRefresh }: ServiceRowProps) {
   const url = serviceUrl(domain, service);
   const [outputOpen, setOutputOpen] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  async function handleAction(action: "stop" | "start" | "restart") {
+    setActionLoading(action);
+    try {
+      if (action === "stop") await stopProcess(projectName, name);
+      else if (action === "start") await startProcess(projectName, name);
+      else await restartProcess(projectName, name);
+      onRefresh();
+    } finally {
+      setActionLoading(null);
+    }
+  }
 
   return (
     <div className="flex items-center gap-2 text-sm py-1">
@@ -65,6 +80,51 @@ export function ServiceRow({ name, service, health, domain, process, projectName
         <Badge variant="outline" className="text-xs">
           {process.restarts} restart{process.restarts !== 1 ? "s" : ""}
         </Badge>
+      )}
+      {process && process.running && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                disabled={actionLoading !== null}
+                onClick={() => handleAction("stop")}
+              >
+                <Square className={actionLoading === "stop" ? "animate-pulse" : ""} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Stop</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                disabled={actionLoading !== null}
+                onClick={() => handleAction("restart")}
+              >
+                <RotateCw className={actionLoading === "restart" ? "animate-spin" : ""} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Restart</TooltipContent>
+          </Tooltip>
+        </>
+      )}
+      {process && process.stopped && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              disabled={actionLoading !== null}
+              onClick={() => handleAction("start")}
+            >
+              <Play className={actionLoading === "start" ? "animate-pulse" : ""} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Start</TooltipContent>
+        </Tooltip>
       )}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ export interface ProcessStatus {
   service: string;
   command: string;
   running: boolean;
+  stopped: boolean;
   restarts: number;
   started_at: string;
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/httphatch/hatch/internal/certs"
 	"github.com/httphatch/hatch/internal/config"
+	"github.com/httphatch/hatch/internal/process"
 )
 
 // maxBodySize is the maximum allowed request body (1 MB).
@@ -216,6 +218,7 @@ func (s *Server) handleProcesses(w http.ResponseWriter, r *http.Request) {
 		Service   string `json:"service"`
 		Command   string `json:"command"`
 		Running   bool   `json:"running"`
+		Stopped   bool   `json:"stopped"`
 		Restarts  int    `json:"restarts"`
 		StartedAt string `json:"started_at"`
 	}
@@ -227,6 +230,7 @@ func (s *Server) handleProcesses(w http.ResponseWriter, r *http.Request) {
 			Service:   id.Service,
 			Command:   st.Command,
 			Running:   st.Running,
+			Stopped:   st.Stopped,
 			Restarts:  st.Restarts,
 			StartedAt: st.StartedAt.Format(time.RFC3339),
 		})
@@ -238,6 +242,65 @@ func (s *Server) handleProcesses(w http.ResponseWriter, r *http.Request) {
 		return result[i].Service < result[j].Service
 	})
 	writeJSON(w, http.StatusOK, result)
+}
+
+func processErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, process.ErrProcessNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, process.ErrAlreadyStopped), errors.Is(err, process.ErrAlreadyRunning):
+		return http.StatusConflict
+	default:
+		return http.StatusBadRequest
+	}
+}
+
+func (s *Server) handleProcessStop(w http.ResponseWriter, r *http.Request) {
+	if s.processes == nil {
+		writeError(w, http.StatusNotImplemented, "process control not available")
+		return
+	}
+	id := process.ServiceID{
+		Project: r.PathValue("project"),
+		Service: r.PathValue("service"),
+	}
+	if err := s.processes.StopProcess(id); err != nil {
+		writeError(w, processErrorStatus(err), err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+}
+
+func (s *Server) handleProcessStart(w http.ResponseWriter, r *http.Request) {
+	if s.processes == nil {
+		writeError(w, http.StatusNotImplemented, "process control not available")
+		return
+	}
+	id := process.ServiceID{
+		Project: r.PathValue("project"),
+		Service: r.PathValue("service"),
+	}
+	if err := s.processes.StartProcess(id); err != nil {
+		writeError(w, processErrorStatus(err), err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "started"})
+}
+
+func (s *Server) handleProcessRestart(w http.ResponseWriter, r *http.Request) {
+	if s.processes == nil {
+		writeError(w, http.StatusNotImplemented, "process control not available")
+		return
+	}
+	id := process.ServiceID{
+		Project: r.PathValue("project"),
+		Service: r.PathValue("service"),
+	}
+	if err := s.processes.RestartProcess(id); err != nil {
+		writeError(w, processErrorStatus(err), err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "restarted"})
 }
 
 func (s *Server) handleProcessOutput(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -25,9 +25,12 @@ type DashboardShower interface {
 	ShowDashboard()
 }
 
-// ProcessStatuser provides a snapshot of managed process statuses.
-type ProcessStatuser interface {
+// ProcessController provides process status and control operations.
+type ProcessController interface {
 	Statuses() map[process.ServiceID]process.ProcessStatus
+	StopProcess(id process.ServiceID) error
+	StartProcess(id process.ServiceID) error
+	RestartProcess(id process.ServiceID) error
 }
 
 // Server is the HTTP API server for the Hatch dashboard.
@@ -36,7 +39,7 @@ type Server struct {
 	daemon    DaemonControl
 	dashboard DashboardShower
 	health    *health.Checker
-	processes ProcessStatuser
+	processes ProcessController
 	caPaths   certs.CAPaths
 	version   string
 	startTime time.Time
@@ -49,7 +52,7 @@ type Server struct {
 type ServerConfig struct {
 	Addr      string
 	Health    *health.Checker
-	Processes ProcessStatuser
+	Processes ProcessController
 	Daemon    DaemonControl
 	Dashboard DashboardShower
 	CAPaths   certs.CAPaths
@@ -122,6 +125,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PATCH /api/projects/{name}/toggle", s.handleToggleProject)
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/processes", s.handleProcesses)
+	mux.HandleFunc("POST /api/processes/{project}/{service}/stop", requireJSON(s.handleProcessStop))
+	mux.HandleFunc("POST /api/processes/{project}/{service}/start", requireJSON(s.handleProcessStart))
+	mux.HandleFunc("POST /api/processes/{project}/{service}/restart", requireJSON(s.handleProcessRestart))
 	mux.HandleFunc("GET /api/processes/output", s.handleProcessOutput)
 	mux.HandleFunc("GET /api/logs", s.handleLogs)
 	mux.HandleFunc("GET /api/config", s.handleGetConfig)

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -2,6 +2,8 @@ package process
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,6 +21,12 @@ const (
 	backoffResetTime = 60 * time.Second
 )
 
+var (
+	ErrProcessNotFound   = errors.New("process not found")
+	ErrAlreadyStopped    = errors.New("process is already stopped")
+	ErrAlreadyRunning    = errors.New("process is already running")
+)
+
 // ServiceID uniquely identifies a managed process.
 type ServiceID struct {
 	Project string
@@ -31,9 +39,10 @@ func (id ServiceID) String() string {
 
 // ProcessStatus holds the current state of a managed process.
 type ProcessStatus struct {
-	Command  string    `json:"command"`
-	Running  bool      `json:"running"`
-	Restarts int       `json:"restarts"`
+	Command   string    `json:"command"`
+	Running   bool      `json:"running"`
+	Stopped   bool      `json:"stopped"`
+	Restarts  int       `json:"restarts"`
 	StartedAt time.Time `json:"started_at"`
 }
 
@@ -55,6 +64,7 @@ type supervised struct {
 	mu       sync.Mutex
 	restarts int
 	started  time.Time
+	stopped  bool
 }
 
 // Manager supervises processes defined in the Hatch config.
@@ -177,12 +187,80 @@ func (m *Manager) Statuses() map[ServiceID]ProcessStatus {
 		out[id] = ProcessStatus{
 			Command:   sup.command,
 			Running:   running,
+			Stopped:   sup.stopped,
 			Restarts:  sup.restarts,
 			StartedAt: sup.started,
 		}
 		sup.mu.Unlock()
 	}
 	return out
+}
+
+// StopProcess manually stops a running process. The process remains in the
+// process map but will not auto-restart until explicitly started again.
+func (m *Manager) StopProcess(id ServiceID) error {
+	m.mu.Lock()
+	sup, ok := m.processes[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("%w: %v", ErrProcessNotFound, id)
+	}
+	sup.mu.Lock()
+	if sup.stopped {
+		sup.mu.Unlock()
+		m.mu.Unlock()
+		return fmt.Errorf("%w: %v", ErrAlreadyStopped, id)
+	}
+	sup.stopped = true
+	sup.mu.Unlock()
+	sup.cancel()
+	m.mu.Unlock()
+	<-sup.done
+	return nil
+}
+
+// StartProcess resumes a manually stopped process by replacing the old
+// supervised entry with a fresh one, avoiding mutation of shared fields.
+func (m *Manager) StartProcess(id ServiceID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sup, ok := m.processes[id]
+	if !ok {
+		return fmt.Errorf("%w: %v", ErrProcessNotFound, id)
+	}
+	sup.mu.Lock()
+	if !sup.stopped {
+		sup.mu.Unlock()
+		return fmt.Errorf("%w: %v", ErrAlreadyRunning, id)
+	}
+	sup.mu.Unlock()
+
+	newSup := m.startSupervised(id, sup.command, sup.dir, sup.env)
+	m.processes[id] = newSup
+	return nil
+}
+
+// RestartProcess restarts a process. If running, it stops then starts it.
+// If already stopped, it just starts it.
+func (m *Manager) RestartProcess(id ServiceID) error {
+	m.mu.Lock()
+	sup, ok := m.processes[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("%w: %v", ErrProcessNotFound, id)
+	}
+	sup.mu.Lock()
+	wasStopped := sup.stopped
+	sup.mu.Unlock()
+	m.mu.Unlock()
+
+	if !wasStopped {
+		if err := m.StopProcess(id); err != nil {
+			return fmt.Errorf("stopping process: %w", err)
+		}
+	}
+	return m.StartProcess(id)
 }
 
 type desiredProcess struct {
@@ -321,12 +399,16 @@ func (m *Manager) supervise(ctx context.Context, sup *supervised) {
 		case <-runner.Done():
 		}
 
-		// Don't restart if context is cancelled.
+		// Don't restart if context is cancelled or manually stopped.
 		if ctx.Err() != nil {
 			return
 		}
 
 		sup.mu.Lock()
+		if sup.stopped {
+			sup.mu.Unlock()
+			return
+		}
 		if time.Since(startedAt) >= backoffResetTime {
 			backoff = minBackoff
 			sup.restarts = 0

--- a/internal/process/manager_test.go
+++ b/internal/process/manager_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -327,6 +328,145 @@ func TestManager_StartedAtUpdatesOnRestart(t *testing.T) {
 		default:
 			time.Sleep(50 * time.Millisecond)
 		}
+	}
+}
+
+func TestManager_StopProcess(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+
+	if err := mgr.StopProcess(id); err != nil {
+		t.Fatalf("StopProcess: %v", err)
+	}
+
+	st := mgr.Statuses()[id]
+	if st.Running {
+		t.Error("expected process to not be running after stop")
+	}
+	if !st.Stopped {
+		t.Error("expected process to be marked as stopped")
+	}
+
+	// Verify it stays stopped (no auto-restart) by waiting a bit.
+	time.Sleep(2 * time.Second)
+	st = mgr.Statuses()[id]
+	if st.Running {
+		t.Error("expected process to remain stopped, but it restarted")
+	}
+}
+
+func TestManager_StartProcess(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+
+	if err := mgr.StopProcess(id); err != nil {
+		t.Fatalf("StopProcess: %v", err)
+	}
+
+	if err := mgr.StartProcess(id); err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st := mgr.Statuses()[id]
+	if st.Stopped {
+		t.Error("expected process to not be marked as stopped after start")
+	}
+}
+
+func TestManager_RestartProcess(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st1 := mgr.Statuses()[id]
+
+	if err := mgr.RestartProcess(id); err != nil {
+		t.Fatalf("RestartProcess: %v", err)
+	}
+
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st2 := mgr.Statuses()[id]
+	if !st2.StartedAt.After(st1.StartedAt) {
+		t.Error("expected new start time after restart")
+	}
+}
+
+func TestManager_RestartProcess_FromStopped(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+
+	if err := mgr.StopProcess(id); err != nil {
+		t.Fatalf("StopProcess: %v", err)
+	}
+
+	if err := mgr.RestartProcess(id); err != nil {
+		t.Fatalf("RestartProcess from stopped: %v", err)
+	}
+
+	waitForRunning(t, mgr, id, 5*time.Second)
+	st := mgr.Statuses()[id]
+	if !st.Running {
+		t.Error("expected process to be running after restart from stopped")
+	}
+}
+
+func TestManager_StopProcess_NotFound(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+
+	id := ServiceID{Project: "unknown", Service: "svc"}
+	err := mgr.StopProcess(id)
+	if err == nil {
+		t.Fatal("expected error for unknown ServiceID")
+	}
+	if !errors.Is(err, ErrProcessNotFound) {
+		t.Errorf("expected ErrProcessNotFound, got: %v", err)
+	}
+}
+
+func TestManager_StartProcess_AlreadyRunning(t *testing.T) {
+	mgr := NewManager(ManagerConfig{})
+	defer func() { _ = mgr.Stop() }()
+
+	if err := mgr.ApplyConfig(testAppConfig("sleep 60")); err != nil {
+		t.Fatal(err)
+	}
+
+	id := ServiceID{Project: "myapp", Service: "worker"}
+	waitForRunning(t, mgr, id, 5*time.Second)
+
+	err := mgr.StartProcess(id)
+	if err == nil {
+		t.Fatal("expected error when starting an already running process")
+	}
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("expected ErrAlreadyRunning, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `StopProcess`, `StartProcess`, `RestartProcess` methods to the process manager with a `stopped` bool field that prevents auto-restart
- Adds three API routes (`POST /api/processes/{project}/{service}/stop|start|restart`) with proper HTTP status codes (404, 409) via sentinel errors
- Adds `hatch process stop|start|restart <project>/<service>` CLI subcommands
- Adds Stop, Start, and Restart buttons to the dashboard service row UI with loading states

## Test plan
- [x] `go test -race ./...` passes (6 new tests for process control methods)
- [x] `go vet ./...` clean
- [x] `make build` succeeds
- [x] `cd frontend && npm run build` succeeds
- [ ] Manual: `hatch process stop myapp/worker` stops the process, no auto-restart
- [ ] Manual: `hatch process start myapp/worker` resumes the process
- [ ] Manual: `hatch process restart myapp/worker` restarts the process
- [ ] Manual: Dashboard buttons perform the same operations

Closes #28