### PR TITLE
Add Cloudflare Tunnel support

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -48,6 +49,39 @@ func runStatus() error {
 	go func() {
 		defer updateWg.Done()
 		updateHint = checkUpdateHint()
+	}()
+
+	// Fetch tunnel statuses from daemon in background.
+	type tunnelInfo struct {
+		Project string `json:"project"`
+		Service string `json:"service"`
+		URL     string `json:"url"`
+		Type    string `json:"type"`
+		Running bool   `json:"running"`
+	}
+	tunnelMap := make(map[string]tunnelInfo) // "project/service" -> info
+	var tunnelWg sync.WaitGroup
+	tunnelWg.Add(1)
+	go func() {
+		defer tunnelWg.Done()
+		client := &http.Client{Timeout: 3 * time.Second}
+		resp, err := client.Get(daemonBaseURL + "/api/tunnels")
+		if err != nil {
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return
+		}
+		var tunnels []tunnelInfo
+		if err := json.NewDecoder(resp.Body).Decode(&tunnels); err != nil {
+			return
+		}
+		for _, t := range tunnels {
+			if t.Running {
+				tunnelMap[t.Project+"/"+t.Service] = t
+			}
+		}
 	}()
 
 	// Daemon state
@@ -100,10 +134,13 @@ func runStatus() error {
 		}
 		sort.Strings(svcNames)
 
+		// Wait for tunnel data before rendering the table.
+		tunnelWg.Wait()
+
 		// Compute column widths
-		nameW, domainW, upstreamW := len("SERVICE"), len("DOMAIN"), len("UPSTREAM")
+		nameW, domainW, upstreamW, tunnelW := len("SERVICE"), len("DOMAIN"), len("UPSTREAM"), 0
 		type row struct {
-			name, domain, upstream, status string
+			name, domain, upstream, status, tunnelURL string
 		}
 		rows := make([]row, 0, len(svcNames))
 
@@ -119,6 +156,11 @@ func runStatus() error {
 				status = red("✗") + " unhealthy"
 			}
 
+			tunnelURL := ""
+			if t, ok := tunnelMap[name+"/"+svcName]; ok {
+				tunnelURL = t.URL
+			}
+
 			if len(svcName) > nameW {
 				nameW = len(svcName)
 			}
@@ -128,16 +170,39 @@ func runStatus() error {
 			if len(upstream) > upstreamW {
 				upstreamW = len(upstream)
 			}
+			if len(tunnelURL) > tunnelW {
+				tunnelW = len(tunnelURL)
+			}
 
-			rows = append(rows, row{svcName, domain, upstream, status})
+			rows = append(rows, row{svcName, domain, upstream, status, tunnelURL})
+		}
+
+		// Check if any tunnels are active for this project.
+		hasTunnels := false
+		for _, r := range rows {
+			if r.tunnelURL != "" {
+				hasTunnels = true
+				break
+			}
 		}
 
 		// Print table header
-		fmt.Printf("  %-*s  %-*s  %-*s  %s\n", nameW, "SERVICE", domainW, "DOMAIN", upstreamW, "UPSTREAM", "STATUS")
+		if hasTunnels {
+			if tunnelW < len("TUNNEL") {
+				tunnelW = len("TUNNEL")
+			}
+			fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s\n", nameW, "SERVICE", domainW, "DOMAIN", upstreamW, "UPSTREAM", tunnelW, "TUNNEL", "STATUS")
+		} else {
+			fmt.Printf("  %-*s  %-*s  %-*s  %s\n", nameW, "SERVICE", domainW, "DOMAIN", upstreamW, "UPSTREAM", "STATUS")
+		}
 
 		// Print rows
 		for _, r := range rows {
-			fmt.Printf("  %-*s  %-*s  %-*s  %s\n", nameW, r.name, domainW, r.domain, upstreamW, r.upstream, r.status)
+			if hasTunnels {
+				fmt.Printf("  %-*s  %-*s  %-*s  %-*s  %s\n", nameW, r.name, domainW, r.domain, upstreamW, r.upstream, tunnelW, r.tunnelURL, r.status)
+			} else {
+				fmt.Printf("  %-*s  %-*s  %-*s  %s\n", nameW, r.name, domainW, r.domain, upstreamW, r.upstream, r.status)
+			}
 		}
 	}
 

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var tunnelCmd = &cobra.Command{
+	Use:   "tunnel",
+	Short: "Manage Cloudflare tunnels",
+}
+
+var tunnelStartCmd = &cobra.Command{
+	Use:   "start <project>/<service>",
+	Short: "Start a Cloudflare tunnel for a service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		project, service, err := parseTunnelArg(args[0])
+		if err != nil {
+			return err
+		}
+		endpoint := fmt.Sprintf("%s/api/tunnels/%s/%s/start", daemonBaseURL, url.PathEscape(project), url.PathEscape(service))
+		client := &http.Client{Timeout: 30 * time.Second}
+		httpResp, err := client.Post(endpoint, "application/json", strings.NewReader("{}"))
+		if err != nil {
+			return fmt.Errorf("daemon not running, start with: hatch up")
+		}
+		defer func() { _ = httpResp.Body.Close() }()
+		if httpResp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to start tunnel (status %d)", httpResp.StatusCode)
+		}
+		var resp struct {
+			URL    string `json:"url"`
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+		fmt.Printf("%s %s/%s\n", color.New(color.FgGreen, color.Bold).Sprint("Started"), project, service)
+		if resp.URL != "" {
+			fmt.Println(resp.URL)
+		}
+		return nil
+	},
+}
+
+var tunnelStopCmd = &cobra.Command{
+	Use:   "stop <project>/<service>",
+	Short: "Stop a Cloudflare tunnel for a service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		project, service, err := parseTunnelArg(args[0])
+		if err != nil {
+			return err
+		}
+		endpoint := fmt.Sprintf("%s/api/tunnels/%s/%s/stop", daemonBaseURL, url.PathEscape(project), url.PathEscape(service))
+		client := &http.Client{Timeout: 30 * time.Second}
+		httpResp, err := client.Post(endpoint, "application/json", strings.NewReader("{}"))
+		if err != nil {
+			return fmt.Errorf("daemon not running, start with: hatch up")
+		}
+		defer func() { _ = httpResp.Body.Close() }()
+		if httpResp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to stop tunnel (status %d)", httpResp.StatusCode)
+		}
+		fmt.Printf("%s %s/%s\n", color.New(color.FgRed, color.Bold).Sprint("Stopped"), project, service)
+		return nil
+	},
+}
+
+var tunnelStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show status of all Cloudflare tunnels",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		endpoint := fmt.Sprintf("%s/api/tunnels", daemonBaseURL)
+		client := &http.Client{Timeout: 30 * time.Second}
+		httpResp, err := client.Get(endpoint)
+		if err != nil {
+			return fmt.Errorf("daemon not running, start with: hatch up")
+		}
+		defer func() { _ = httpResp.Body.Close() }()
+		if httpResp.StatusCode != http.StatusOK {
+			return fmt.Errorf("failed to get tunnel status (status %d)", httpResp.StatusCode)
+		}
+		var tunnels []struct {
+			Project   string `json:"project"`
+			Service   string `json:"service"`
+			Running   bool   `json:"running"`
+			URL       string `json:"url"`
+			Type      string `json:"type"`
+			StartedAt string `json:"started_at"`
+			Error     string `json:"error"`
+		}
+		if err := json.NewDecoder(httpResp.Body).Decode(&tunnels); err != nil {
+			return fmt.Errorf("decoding response: %w", err)
+		}
+		if len(tunnels) == 0 {
+			fmt.Println("No active tunnels")
+			return nil
+		}
+		header := color.New(color.Bold)
+		_, _ = header.Printf("%-30s %-10s %-50s %-12s\n", "PROJECT/SERVICE", "TYPE", "URL", "UPTIME")
+		for _, t := range tunnels {
+			name := t.Project + "/" + t.Service
+			uptime := ""
+			if t.StartedAt != "" {
+				if started, err := time.Parse(time.RFC3339, t.StartedAt); err == nil {
+					uptime = time.Since(started).Truncate(time.Second).String()
+				}
+			}
+			fmt.Printf("%-30s %-10s %-50s %-12s\n", name, t.Type, t.URL, uptime)
+		}
+		return nil
+	},
+}
+
+func parseTunnelArg(arg string) (project, service string, err error) {
+	project, service, ok := strings.Cut(arg, "/")
+	if !ok || project == "" || service == "" {
+		return "", "", fmt.Errorf("invalid format %q, expected <project>/<service>", arg)
+	}
+	return project, service, nil
+}
+
+func init() {
+	tunnelCmd.AddCommand(tunnelStartCmd)
+	tunnelCmd.AddCommand(tunnelStopCmd)
+	tunnelCmd.AddCommand(tunnelStatusCmd)
+	rootCmd.AddCommand(tunnelCmd)
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
           { text: 'What is Hatch?', link: '/guide/what-is-hatch' },
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Dashboard', link: '/guide/dashboard' },
+          { text: 'Tunnels', link: '/guide/tunnels' },
         ],
       },
       {

--- a/docs/advanced/how-it-works.md
+++ b/docs/advanced/how-it-works.md
@@ -119,9 +119,11 @@ A plist file is installed at `~/Library/LaunchAgents/dev.hatch.daemon.plist`. Ke
 4. Start DNS server
 5. Start Caddy with translated config
 6. Start health checker
-7. Start API server (`127.0.0.1:42824`)
-8. Start config file watcher
-9. Block until shutdown signal
+7. Start process manager (supervised commands)
+8. Start tunnel manager (Cloudflare Tunnels)
+9. Start API server (`127.0.0.1:42824`)
+10. Start config file watcher
+11. Block until shutdown signal
 
 ### Config Watching
 
@@ -131,6 +133,7 @@ The daemon watches `~/.hatch/config.yml` for changes using filesystem notificati
 2. Re-translate to Caddy JSON
 3. Push to Caddy via admin API
 4. Update health checker targets
+5. Reconcile tunnels (start new, stop removed)
 
 No daemon restart is required for config changes.
 
@@ -154,9 +157,28 @@ Key endpoints:
 | PUT | `/api/config` | Write config (YAML) |
 | GET | `/api/certs` | Certificate status |
 | GET | `/api/processes` | Process statuses |
+| GET | `/api/tunnels` | Tunnel statuses |
+| POST | `/api/tunnels/{project}/{service}/start` | Start a tunnel |
+| POST | `/api/tunnels/{project}/{service}/stop` | Stop a tunnel |
 | POST | `/api/restart` | Reload config |
 
 The API is localhost-only and used by both the CLI commands and the React dashboard.
+
+## Tunnels
+
+Hatch can expose local services to the internet via [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/). It runs cloudflared as a subprocess, one per active tunnel.
+
+**Quick tunnels** use `cloudflared tunnel --url <upstream>`. Hatch scans stdout for a `trycloudflare.com` URL and waits up to 30 seconds for it to appear. No Cloudflare account is needed.
+
+**Named tunnels** use `cloudflared tunnel run <name>` with the API token passed via the `TUNNEL_TOKEN` environment variable (never exposed in process arguments).
+
+**Rewrite proxy:** Quick tunnels route through a local rewrite proxy that sits between cloudflared and the upstream. The proxy does three things: (1) strips absolute localhost URLs from HTML responses so browsers don't block them under PNA policy, (2) discovers a secondary dev server (e.g. Vite) by finding localhost URLs on a different port than the upstream, and retries 404'd GET requests against it, (3) retries failed WebSocket upgrades against the dev server so HMR works through the tunnel. Named tunnels skip the proxy and connect directly to the upstream.
+
+**Binary discovery:** Hatch uses `exec.LookPath` to find cloudflared. On macOS, it also checks `/opt/homebrew/bin/cloudflared` and `/usr/local/bin/cloudflared` as fallbacks for launchd environments where Homebrew's bin directory is not in PATH.
+
+**Lifecycle:** The tunnel manager starts tunnels in background goroutines on daemon boot or config reload. Tunnel startup does not block the daemon. Tunnels are stopped on shutdown or when removed from config. If a tunnel process exits unexpectedly, it stays stopped. There is no automatic retry.
+
+**State persistence:** Running tunnel metadata (URLs, types, timestamps) is written to `~/.hatch/tunnels.json` for CLI status display. This is informational only; the manager does not restore tunnels from this file on startup.
 
 ## Health Checking
 
@@ -184,6 +206,7 @@ Services with a `command` field are managed as supervised processes.
 | `~/.hatch/certs/` | CA certificates and keys |
 | `~/.hatch/logs/hatch.log` | Daemon log file |
 | `~/.hatch/hatch.pid` | Daemon PID lock file |
+| `~/.hatch/tunnels.json` | Active tunnel metadata |
 | `~/.hatch/caddy/` | Caddy data (cached site certs) |
 | `/etc/resolver/<tld>` | macOS DNS resolver override |
 | `~/Library/LaunchAgents/dev.hatch.daemon.plist` | Launchd service |

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -32,6 +32,17 @@ Services configured with a `command` show a process status indicator:
 
 A restart count badge appears when the process has been restarted automatically.
 
+### Tunnel Controls
+
+Services with a `proxy` can be exposed to the internet via Cloudflare Tunnels. Each service row shows a tunnel button:
+
+- **Start** (cloud icon) — starts a quick tunnel for the service
+- **Starting** — pulsing badge while cloudflared initializes (can take up to 30 seconds)
+- **Running** — displays the public URL as a clickable link, with a stop button (cloud-off icon)
+- **Error** — brief error message if the action fails (auto-clears after 5 seconds)
+
+Tunnel output from cloudflared appears in the service's terminal viewer alongside process output. Tunnel status updates automatically via polling. See [Tunnels](/guide/tunnels) for setup.
+
 ### Route Map
 
 Each project shows a visual route map of how requests are routed:

--- a/docs/guide/tunnels.md
+++ b/docs/guide/tunnels.md
@@ -1,0 +1,172 @@
+# Tunnels
+
+Hatch can expose your local services to the internet using [Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/). This is useful for sharing work with teammates, testing webhooks, and mobile device testing.
+
+## Prerequisites
+
+Install cloudflared:
+
+```bash
+brew install cloudflared
+```
+
+Hatch runs cloudflared as a subprocess. It checks your PATH and standard Homebrew locations (`/opt/homebrew/bin/cloudflared`, `/usr/local/bin/cloudflared`), so it works even when the daemon runs under launchd with a minimal PATH. If cloudflared is not found, tunnel commands will return a clear error.
+
+## Quick Tunnels
+
+Quick tunnels require no Cloudflare account. They give you a temporary public URL on `trycloudflare.com` that routes to your local service.
+
+Add `tunnel: true` to any service with a `proxy`:
+
+```yaml
+# hatch.yml
+domain: myapp.test
+services:
+  web:
+    proxy: http://localhost:3000
+    tunnel: true
+```
+
+Or start one on demand:
+
+```bash
+hatch tunnel start myapp/web
+```
+
+The URL is printed when the tunnel starts:
+
+```
+Started tunnel myapp/web
+URL: https://random-words.trycloudflare.com
+```
+
+Quick tunnel URLs are temporary. They change each time the tunnel is started.
+
+## Named Tunnels
+
+Named tunnels give you a persistent domain through your Cloudflare account. You need a Cloudflare API token and a pre-configured tunnel in the Cloudflare dashboard.
+
+Set the token globally or per-project:
+
+```yaml
+# ~/.hatch/config.yml
+version: 1
+settings:
+  cloudflare_token: "your-global-token"
+projects:
+  myapp:
+    domain: myapp.test
+    path: /Users/me/projects/myapp
+    cloudflare_token: "project-specific-token"  # overrides global
+    services:
+      web:
+        proxy: http://localhost:3000
+        tunnel: my-tunnel-name
+```
+
+The tunnel name must match a tunnel configured in your Cloudflare dashboard. Tokens are never exposed in process arguments or API responses.
+
+## CLI Commands
+
+### `hatch tunnel start <project>/<service>`
+
+Start a tunnel for a specific service.
+
+```bash
+hatch tunnel start myapp/web
+```
+
+### `hatch tunnel stop <project>/<service>`
+
+Stop a running tunnel.
+
+```bash
+hatch tunnel stop myapp/web
+```
+
+### `hatch tunnel status`
+
+List all tunnels with their type, URL, and uptime.
+
+```bash
+hatch tunnel status
+```
+
+Output:
+
+```
+PROJECT/SERVICE  TYPE   URL                                      UPTIME
+myapp/web        quick  https://random-words.trycloudflare.com   5m ago
+myapp/api        named  (configured in Cloudflare)                2h ago
+```
+
+## Config-Driven Tunnels
+
+When `tunnel` is set in the config, Hatch starts the tunnel automatically when the daemon starts or the config reloads. Removing or clearing the `tunnel` field stops the tunnel.
+
+Tunnels start in the background and do not block the daemon from booting. Quick tunnels can take up to 30 seconds to obtain a URL from cloudflared. During this time, the dashboard shows a "Starting tunnel..." indicator.
+
+This means you can manage tunnels entirely through config changes, without running CLI commands.
+
+## Dashboard
+
+The dashboard shows tunnel controls next to each service:
+
+- **Start button** (cloud icon) — starts a quick tunnel for any service with a proxy
+- **Starting state** — shows a pulsing "Starting tunnel..." badge while cloudflared initializes
+- **Running state** — displays the public URL as a clickable link, with a stop button
+- **Error state** — shows a brief error message if the tunnel action fails (auto-clears after 5 seconds)
+
+Tunnel output (cloudflared stdout/stderr) appears in the service's terminal viewer alongside process output. Click the terminal icon on any service row to view it.
+
+## How It Works
+
+For quick tunnels, Hatch runs a local rewrite proxy between cloudflared and your dev server. The proxy solves two problems that occur when accessing local dev servers through a public tunnel URL.
+
+### URL rewriting
+
+Dev servers like Vite inject absolute localhost URLs into HTML responses (e.g. `http://[::1]:5173/@vite/client`). Browsers block these under Private Network Access (PNA) policy when the page loads from a public origin. The rewrite proxy strips all `http://`, `https://`, `ws://`, and `wss://` URLs pointing to `localhost`, `127.0.0.1`, or `[::1]` on any port from HTML responses. This turns them into relative paths that resolve through the tunnel. Non-HTML responses pass through unchanged.
+
+### Dev server fallback
+
+In setups like Laravel + Vite, the app server and dev server run on different ports. Laravel serves HTML, Vite serves JS/CSS assets. When the proxy rewrites HTML, it discovers the dev server by finding localhost URLs on a port different from the upstream. For subsequent requests that 404 on the upstream (because Laravel doesn't serve Vite assets), the proxy retries against the discovered dev server.
+
+The same fallback applies to WebSocket upgrades. When the upstream doesn't return 101 Switching Protocols (because it doesn't handle WebSocket), the proxy retries against the dev server. This allows Vite's HMR WebSocket to connect through the tunnel.
+
+### The flow
+
+Single-server setup (e.g. plain Vite):
+
+```
+Browser → trycloudflare.com → cloudflared → rewrite proxy → localhost:3000
+```
+
+Multi-server setup (e.g. Laravel + Vite):
+
+```
+Browser → trycloudflare.com → cloudflared → rewrite proxy → Laravel (port 8000)
+                                                          ↘ Vite (port 5173) on 404/WS
+```
+
+### Tunnel processes
+
+Hatch runs a cloudflared subprocess for each active tunnel:
+
+- **Quick tunnels** run `cloudflared tunnel --url http://127.0.0.1:<proxy-port>` and parse the URL from stdout. Quick tunnels wait up to 30 seconds for cloudflared to provide a URL.
+- **Named tunnels** run `cloudflared tunnel run <name>` with the token passed via environment variable. Named tunnels connect directly to the upstream without a rewrite proxy.
+
+The tunnel manager tracks state in `~/.hatch/tunnels.json` for CLI status display. This file is informational only; tunnels are not restored on daemon restart.
+
+If a tunnel process exits unexpectedly, it stays stopped until manually restarted or the config is reloaded. There is no automatic retry.
+
+## Vite and HMR
+
+Vite's hot module replacement works through tunnels without any Vite configuration. The rewrite proxy handles everything:
+
+1. Absolute localhost script URLs in HTML are rewritten to relative paths
+2. Asset requests (JS, CSS) that 404 on the app server are retried against the Vite dev server
+3. WebSocket upgrade requests for HMR are forwarded to the Vite dev server
+
+You may see a console warning about a failed WebSocket to `wss://localhost:PORT`. This is Vite's client attempting a direct localhost connection as a fallback. It is harmless because the primary WebSocket through the tunnel URL succeeds.
+
+For quick tunnels, the URL changes each time. HMR live-reloading may require a manual page refresh after restarting the tunnel.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,9 @@ features:
   - title: Reverse Proxy
     details: Routes requests to your local services with path-based and subdomain-based routing.
     icon: 🔀
+  - title: Tunnels
+    details: Share local services publicly via Cloudflare Tunnels. Quick tunnels need no account; named tunnels give you a persistent domain.
+    icon: 🚇
   - title: Dashboard
     details: Visual GUI for managing projects, viewing logs, and monitoring service health.
     icon: 📊

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -10,16 +10,18 @@ Key concepts:
 - **Services**: Each project has one or more services, each proxying to a local upstream (e.g., `http://localhost:3000`). Services can be routed by path prefix or subdomain.
 - **Certificates**: Hatch generates a local root CA and intermediate CA, trusted in the macOS Keychain. Per-domain certificates are issued automatically.
 - **DNS**: A local DNS server resolves `*.test` to localhost via a macOS resolver config in `/etc/resolver/`.
+- **Tunnels**: Expose local services to the internet via Cloudflare Tunnels. Quick tunnels (no account, temporary URL) and named tunnels (persistent domain, requires token). Includes a rewrite proxy that handles Vite/HMR compatibility.
 
 ## Guide
 
 - [What is Hatch?](https://httphatch.com/guide/what-is-hatch): Feature overview and how Hatch compares to editing /etc/hosts or using self-signed certificates.
 - [Getting Started](https://httphatch.com/guide/getting-started): Installation (Homebrew or source), first-time setup with `hatch init`, starting the daemon, and adding your first project.
+- [Tunnels](https://httphatch.com/guide/tunnels): Expose local services via Cloudflare Tunnels — quick tunnels, named tunnels, CLI commands, config-driven tunnels, and Vite/HMR compatibility.
 - [Dashboard](https://httphatch.com/guide/dashboard): Visual GUI for managing projects, viewing logs, and monitoring service health.
 
 ## Reference
 
-- [CLI](https://httphatch.com/reference/cli): Complete command reference — daemon management (`up`, `down`, `restart`, `status`, `logs`), project management (`add`, `link`, `unlink`, `list`, `remove`, `enable`, `disable`, `open`), system setup (`init`, `trust`, `doctor`, `clean`), and config commands.
+- [CLI](https://httphatch.com/reference/cli): Complete command reference — daemon management (`up`, `down`, `restart`, `status`, `logs`), project management (`add`, `link`, `unlink`, `list`, `remove`, `enable`, `disable`, `open`), tunnel management (`tunnel start`, `tunnel stop`, `tunnel status`), system setup (`init`, `trust`, `doctor`, `clean`), and config commands.
 - [Configuration](https://httphatch.com/reference/config): Global config file (`~/.hatch/config.yml`) — TLD, HTTP/HTTPS ports, auto-start, log level, and project/service definitions.
 - [.hatch.yml](https://httphatch.com/reference/hatch-yml): Per-project config file format — domain, services with proxy, route, subdomain, and websocket options.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -180,6 +180,36 @@ Complete uninstall. Stops the daemon, removes the DNS resolver, untrusts the roo
 hatch clean
 ```
 
+## Tunnels
+
+### `hatch tunnel start <project>/<service>`
+
+Start a Cloudflare Tunnel for a service. Requires cloudflared to be installed.
+
+```bash
+hatch tunnel start myapp/web
+```
+
+Prints the public tunnel URL on success. For quick tunnels, the URL is a temporary `trycloudflare.com` address.
+
+### `hatch tunnel stop <project>/<service>`
+
+Stop a running tunnel.
+
+```bash
+hatch tunnel stop myapp/web
+```
+
+### `hatch tunnel status`
+
+List all active tunnels with their type, URL, and uptime.
+
+```bash
+hatch tunnel status
+```
+
+See [Tunnels](/guide/tunnels) for setup and configuration.
+
 ## Config
 
 ### `hatch config`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -15,17 +15,21 @@ settings:
   auto_start: true
   tray_icon: true
   log_level: info
+  cloudflare_token: "global-token"
 projects:
   myapp:
     domain: myapp.test
     path: /Users/me/projects/myapp
     enabled: true
+    cloudflare_token: "project-token"
     services:
       web:
         proxy: http://localhost:3000
+        tunnel: true
       api:
         proxy: http://localhost:8080
         subdomain: api
+        tunnel: my-api-tunnel
       docs:
         proxy: http://localhost:4000
         route: /docs
@@ -97,6 +101,13 @@ Show the Hatch tray icon and status menu (macOS only). Set to `false` to run the
 
 Controls the verbosity of daemon logs in `~/.hatch/logs/hatch.log`.
 
+### `settings.cloudflare_token`
+
+- **Type:** `string`
+- **Optional**
+
+Default Cloudflare API token for named tunnels. Can be overridden per-project. See [Tunnels](/guide/tunnels) for details.
+
 ## Projects
 
 Each key under `projects` is the project name. Projects are a map, so names must be unique.
@@ -121,6 +132,13 @@ Filesystem path to the project directory. Used by `hatch doctor` to detect stale
 - **Default:** `true`
 
 When `false`, the project's routes are excluded from the proxy config.
+
+### `projects.<name>.cloudflare_token`
+
+- **Type:** `string`
+- **Optional**
+
+Project-specific Cloudflare API token. Overrides `settings.cloudflare_token` for this project's named tunnels.
 
 ### `projects.<name>.services`
 
@@ -193,6 +211,25 @@ env_file: .env
 
 Enables WebSocket proxying for this service. Adds the necessary `Connection` and `Upgrade` headers and sets instant response flushing.
 
+### `services.<name>.tunnel`
+
+- **Type:** `string` or `boolean`
+- **Optional**
+
+Exposes this service to the internet via a Cloudflare Tunnel. Requires `proxy` to be set.
+
+- `true` — starts a quick tunnel (temporary URL, no account needed)
+- `"my-tunnel-name"` — starts a named tunnel (persistent domain, requires `cloudflare_token`)
+
+```yaml
+tunnel: true              # quick tunnel
+tunnel: my-tunnel-name    # named tunnel
+```
+
+Named tunnel values must contain only alphanumeric characters, hyphens, or underscores (max 63 characters). Named tunnels require a `cloudflare_token` at the project or settings level.
+
+See [Tunnels](/guide/tunnels) for a full guide.
+
 ## Validation Rules
 
 - `http_port` and `https_port` must be different
@@ -202,3 +239,5 @@ Enables WebSocket proxying for this service. Adds the necessary `Connection` and
 - Service `proxy` must be a valid URL
 - Service `subdomain` must be a valid DNS label
 - `route` and `subdomain` require `proxy`
+- `tunnel` requires `proxy`
+- Named tunnels require `cloudflare_token` at project or settings level

--- a/docs/reference/hatch-yml.md
+++ b/docs/reference/hatch-yml.md
@@ -14,6 +14,7 @@ services:
     route: <path-prefix>         # optional
     subdomain: <subdomain>       # optional
     websocket: <bool>            # optional, default: false
+    tunnel: <bool|string>        # optional
 ```
 
 ### `domain`
@@ -134,3 +135,19 @@ services:
 Produces:
 - `https://myapp.test` → `http://localhost:3000` (process managed by Hatch)
 - `worker` runs as a supervised process with no proxy route
+
+### Tunnel Support
+
+```yaml
+domain: myapp.test
+services:
+  web:
+    proxy: http://localhost:3000
+    tunnel: true
+```
+
+Produces:
+- `https://myapp.test` → `http://localhost:3000` (local)
+- `https://random-words.trycloudflare.com` → `http://localhost:3000` (public)
+
+See [Tunnels](/guide/tunnels) for quick vs named tunnels and token configuration.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { SettingsDialog } from "@/components/settings-dialog";
 import { useProjects } from "@/hooks/use-projects";
 import { useHealth } from "@/hooks/use-health";
 import { useProcesses } from "@/hooks/use-processes";
+import { useTunnels } from "@/hooks/use-tunnels";
 import { useStatus } from "@/hooks/use-status";
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
     useProjects();
   const { lookup } = useHealth();
   const { lookup: processLookup, refresh: refreshProcesses } = useProcesses();
+  const { lookup: tunnelLookup, refresh: refreshTunnels } = useTunnels();
   const { status } = useStatus();
 
   const [addOpen, setAddOpen] = useState(false);
@@ -57,7 +59,9 @@ function App() {
               onEdit={setEditTarget}
               onDelete={handleDelete}
               onAdd={() => setAddOpen(true)}
+              tunnelLookup={tunnelLookup}
               onProcessRefresh={refreshProcesses}
+              onTunnelRefresh={refreshTunnels}
             />
             <RouteMap projects={projects} healthLookup={lookup} />
           </>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { CertStatus, DaemonStatus, ProcessStatus, Project, ServiceHealth } from "./types";
+import type { CertStatus, DaemonStatus, ProcessStatus, Project, ServiceHealth, TunnelStatus } from "./types";
 
 const BASE = "";
 
@@ -115,4 +115,22 @@ export function restartProcess(project: string, service: string): Promise<void> 
 
 export function getCerts(): Promise<CertStatus> {
   return request("/api/certs");
+}
+
+export function getTunnels(): Promise<TunnelStatus[]> {
+  return request("/api/tunnels");
+}
+
+export function startTunnel(project: string, service: string): Promise<{ url: string; status: string }> {
+  return request(`/api/tunnels/${encodeURIComponent(project)}/${encodeURIComponent(service)}/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function stopTunnel(project: string, service: string): Promise<void> {
+  return request(`/api/tunnels/${encodeURIComponent(project)}/${encodeURIComponent(service)}/stop`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
 }

--- a/frontend/src/components/project-card.tsx
+++ b/frontend/src/components/project-card.tsx
@@ -13,7 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ServiceRow } from "@/components/service-row";
-import type { ProcessStatus, Project, ServiceHealth } from "@/types";
+import type { ProcessStatus, Project, ServiceHealth, TunnelStatus } from "@/types";
 import { Copy, ExternalLink, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Browser } from "@wailsio/runtime";
@@ -26,7 +26,9 @@ interface ProjectCardProps {
   onToggle: (name: string) => void;
   onEdit: (name: string) => void;
   onDelete: (name: string) => void;
+  tunnelLookup: (project: string, service: string) => TunnelStatus | undefined;
   onProcessRefresh: () => void;
+  onTunnelRefresh: () => void;
 }
 
 export function ProjectCard({
@@ -37,7 +39,9 @@ export function ProjectCard({
   onToggle,
   onEdit,
   onDelete,
+  tunnelLookup,
   onProcessRefresh,
+  onTunnelRefresh,
 }: ProjectCardProps) {
   const url = `https://${project.domain}`;
 
@@ -119,8 +123,10 @@ export function ProjectCard({
               health={healthLookup(name, svcName)}
               domain={project.domain}
               process={processLookup(name, svcName)}
+              tunnel={tunnelLookup(name, svcName)}
               projectName={name}
               onRefresh={onProcessRefresh}
+              onTunnelRefresh={onTunnelRefresh}
             />
           ))}
         </div>

--- a/frontend/src/components/project-list.tsx
+++ b/frontend/src/components/project-list.tsx
@@ -1,6 +1,6 @@
 import { ProjectCard } from "@/components/project-card";
 import { EmptyState } from "@/components/empty-state";
-import type { ProcessStatus, Project, ServiceHealth } from "@/types";
+import type { ProcessStatus, Project, ServiceHealth, TunnelStatus } from "@/types";
 
 interface ProjectListProps {
   projects: Record<string, Project>;
@@ -10,7 +10,9 @@ interface ProjectListProps {
   onEdit: (name: string) => void;
   onDelete: (name: string) => void;
   onAdd: () => void;
+  tunnelLookup: (project: string, service: string) => TunnelStatus | undefined;
   onProcessRefresh: () => void;
+  onTunnelRefresh: () => void;
 }
 
 export function ProjectList({
@@ -21,7 +23,9 @@ export function ProjectList({
   onEdit,
   onDelete,
   onAdd,
+  tunnelLookup,
   onProcessRefresh,
+  onTunnelRefresh,
 }: ProjectListProps) {
   const entries = Object.entries(projects);
 
@@ -41,7 +45,9 @@ export function ProjectList({
           onToggle={onToggle}
           onEdit={onEdit}
           onDelete={onDelete}
+          tunnelLookup={tunnelLookup}
           onProcessRefresh={onProcessRefresh}
+          onTunnelRefresh={onTunnelRefresh}
         />
       ))}
     </div>

--- a/frontend/src/components/service-row.tsx
+++ b/frontend/src/components/service-row.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,9 +9,9 @@ import {
 import { HealthDot } from "@/components/health-dot";
 import { ProcessOutputDialog } from "@/components/process-output-dialog";
 import { serviceUrl } from "@/lib/service-url";
-import { stopProcess, startProcess, restartProcess } from "@/api";
-import type { ProcessStatus, Service, ServiceHealth } from "@/types";
-import { ExternalLink, Play, RotateCw, Square, Terminal } from "lucide-react";
+import { stopProcess, startProcess, restartProcess, startTunnel, stopTunnel } from "@/api";
+import type { ProcessStatus, Service, ServiceHealth, TunnelStatus } from "@/types";
+import { Cloud, CloudOff, ExternalLink, Play, RotateCw, Square, Terminal } from "lucide-react";
 import { Browser } from "@wailsio/runtime";
 
 interface ServiceRowProps {
@@ -20,14 +20,39 @@ interface ServiceRowProps {
   health?: ServiceHealth;
   domain: string;
   process?: ProcessStatus;
+  tunnel?: TunnelStatus;
   projectName: string;
   onRefresh: () => void;
+  onTunnelRefresh: () => void;
 }
 
-export function ServiceRow({ name, service, health, domain, process, projectName, onRefresh }: ServiceRowProps) {
+export function ServiceRow({ name, service, health, domain, process, tunnel, projectName, onRefresh, onTunnelRefresh }: ServiceRowProps) {
   const url = serviceUrl(domain, service);
   const [outputOpen, setOutputOpen] = useState(false);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [tunnelLoading, setTunnelLoading] = useState(false);
+  const [tunnelError, setTunnelError] = useState<string | null>(null);
+
+  // Auto-clear tunnel errors after 5 seconds.
+  useEffect(() => {
+    if (!tunnelError) return;
+    const timer = setTimeout(() => setTunnelError(null), 5000);
+    return () => clearTimeout(timer);
+  }, [tunnelError]);
+
+  async function handleTunnelAction(action: "start" | "stop") {
+    setTunnelLoading(true);
+    setTunnelError(null);
+    try {
+      if (action === "start") await startTunnel(projectName, name);
+      else await stopTunnel(projectName, name);
+      onTunnelRefresh();
+    } catch (err) {
+      setTunnelError(err instanceof Error ? err.message : "Tunnel action failed");
+    } finally {
+      setTunnelLoading(false);
+    }
+  }
 
   async function handleAction(action: "stop" | "start" | "restart") {
     setActionLoading(action);
@@ -125,6 +150,61 @@ export function ServiceRow({ name, service, health, domain, process, projectName
           </TooltipTrigger>
           <TooltipContent>Start</TooltipContent>
         </Tooltip>
+      )}
+      {tunnel && tunnel.running && (
+        <>
+          {tunnel.url && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge
+                  variant="outline"
+                  className="text-xs text-muted-teal border-muted-teal cursor-pointer hover:bg-muted-teal/10"
+                  onClick={() => Browser.OpenURL(tunnel.url)}
+                >
+                  <Cloud className="mr-1 h-3 w-3" />
+                  {tunnel.url.replace(/^https?:\/\//, "")}
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>Open tunnel URL</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                disabled={tunnelLoading}
+                onClick={() => handleTunnelAction("stop")}
+              >
+                <CloudOff className={tunnelLoading ? "animate-pulse" : ""} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Stop tunnel</TooltipContent>
+          </Tooltip>
+        </>
+      )}
+      {service.proxy && (!tunnel || (!tunnel.running && !tunnel.starting)) && !tunnelLoading && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => handleTunnelAction("start")}
+            >
+              <Cloud />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Start tunnel</TooltipContent>
+        </Tooltip>
+      )}
+      {(tunnelLoading || (tunnel && tunnel.starting)) && (
+        <Badge variant="outline" className="text-xs text-text-muted border-text-muted animate-pulse">
+          <Cloud className="mr-1 h-3 w-3" />
+          Starting tunnel...
+        </Badge>
+      )}
+      {tunnelError && (
+        <span className="text-xs text-destructive">{tunnelError}</span>
       )}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/frontend/src/hooks/use-tunnels.ts
+++ b/frontend/src/hooks/use-tunnels.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as api from "@/api";
+import type { TunnelStatus } from "@/types";
+
+export function useTunnels() {
+  const [tunnels, setTunnels] = useState<TunnelStatus[]>([]);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await api.getTunnels();
+      setTunnels(data ?? []);
+    } catch {
+      // silently ignore tunnel poll failures
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    intervalRef.current = setInterval(refresh, 10_000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [refresh]);
+
+  const lookup = useCallback(
+    (project: string, service: string): TunnelStatus | undefined => {
+      return tunnels.find(
+        (t) => t.project === project && t.service === service
+      );
+    },
+    [tunnels]
+  );
+
+  return { tunnels, lookup, refresh };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,6 +5,7 @@ export interface Service {
   websocket?: boolean;
   command?: string;
   env_file?: string;
+  tunnel?: string;
 }
 
 export interface ProcessStatus {
@@ -65,4 +66,15 @@ export interface CertInfo {
 export interface CertStatus {
   root_ca: CertInfo;
   intermediate_ca: CertInfo;
+}
+
+export interface TunnelStatus {
+  project: string;
+  service: string;
+  running: boolean;
+  starting: boolean;
+  url: string;
+  type: "quick" | "named";
+  started_at: string;
+  error?: string;
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -18,6 +19,7 @@ import (
 	"github.com/httphatch/hatch/internal/certs"
 	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/process"
+	"github.com/httphatch/hatch/internal/tunnel"
 )
 
 // maxBodySize is the maximum allowed request body (1 MB).
@@ -70,6 +72,11 @@ func (s *Server) handleListProjects(w http.ResponseWriter, r *http.Request) {
 	if projects == nil {
 		projects = make(map[string]config.Project)
 	}
+	// Strip tokens from API response to avoid leaking secrets.
+	for name, proj := range projects {
+		proj.CloudflareToken = ""
+		projects[name] = proj
+	}
 	writeJSON(w, http.StatusOK, projects)
 }
 
@@ -115,6 +122,7 @@ func (s *Server) handleAddProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to save config")
 		return
 	}
+	req.Project.CloudflareToken = ""
 	writeJSON(w, http.StatusCreated, req.Project)
 }
 
@@ -150,6 +158,7 @@ func (s *Server) handleUpdateProject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to save config")
 		return
 	}
+	proj.CloudflareToken = ""
 	writeJSON(w, http.StatusOK, proj)
 }
 
@@ -249,6 +258,18 @@ func processErrorStatus(err error) int {
 	case errors.Is(err, process.ErrProcessNotFound):
 		return http.StatusNotFound
 	case errors.Is(err, process.ErrAlreadyStopped), errors.Is(err, process.ErrAlreadyRunning):
+		return http.StatusConflict
+	default:
+		return http.StatusBadRequest
+	}
+}
+
+func tunnelErrorStatus(err error) int {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		return http.StatusNotFound
+	case strings.Contains(msg, "already running"), strings.Contains(msg, "already stopped"):
 		return http.StatusConflict
 	default:
 		return http.StatusBadRequest
@@ -456,6 +477,127 @@ func (s *Server) handleShowDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	s.dashboard.ShowDashboard()
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleTunnels(w http.ResponseWriter, r *http.Request) {
+	if s.tunnels == nil {
+		writeJSON(w, http.StatusOK, []any{})
+		return
+	}
+
+	statuses := s.tunnels.Statuses()
+
+	type tunnelInfo struct {
+		Project   string `json:"project"`
+		Service   string `json:"service"`
+		Running   bool   `json:"running"`
+		Starting  bool   `json:"starting"`
+		URL       string `json:"url"`
+		Type      string `json:"type"`
+		StartedAt string `json:"started_at"`
+		Error     string `json:"error,omitempty"`
+	}
+
+	result := make([]tunnelInfo, 0, len(statuses))
+	for id, st := range statuses {
+		startedAt := ""
+		if !st.StartedAt.IsZero() {
+			startedAt = st.StartedAt.Format(time.RFC3339)
+		}
+		result = append(result, tunnelInfo{
+			Project:   id.Project,
+			Service:   id.Service,
+			Running:   st.Running,
+			Starting:  st.Starting,
+			URL:       st.URL,
+			Type:      st.Type,
+			StartedAt: startedAt,
+			Error:     st.Error,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Project != result[j].Project {
+			return result[i].Project < result[j].Project
+		}
+		return result[i].Service < result[j].Service
+	})
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleTunnelStart(w http.ResponseWriter, r *http.Request) {
+	limitBody(r, w)
+	if s.tunnels == nil {
+		writeError(w, http.StatusNotImplemented, "tunnel control not available")
+		return
+	}
+
+	project := r.PathValue("project")
+	service := r.PathValue("service")
+
+	cfg, err := config.LoadWithProjectConfigs()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to load config")
+		return
+	}
+
+	proj, ok := cfg.Projects[project]
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("project %q not found", project))
+		return
+	}
+
+	svc, ok := proj.Services[service]
+	if !ok {
+		writeError(w, http.StatusNotFound, fmt.Sprintf("service %q not found in project %q", service, project))
+		return
+	}
+
+	if svc.Proxy == "" {
+		writeError(w, http.StatusBadRequest, "service has no proxy (nothing to tunnel)")
+		return
+	}
+
+	tunnelVal := string(svc.Tunnel)
+	if tunnelVal == "" {
+		tunnelVal = "true"
+	}
+
+	token := proj.CloudflareToken
+	if token == "" {
+		token = cfg.Settings.CloudflareToken
+	}
+
+	upstream := svc.Proxy
+	id := tunnel.TunnelID{Project: project, Service: service}
+	if err := s.tunnels.StartTunnel(id, upstream, tunnelVal, token); err != nil {
+		writeError(w, tunnelErrorStatus(err), err.Error())
+		return
+	}
+
+	statuses := s.tunnels.Statuses()
+	if st, ok := statuses[id]; ok {
+		writeJSON(w, http.StatusOK, map[string]string{"url": st.URL, "status": "started"})
+	} else {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "started"})
+	}
+}
+
+func (s *Server) handleTunnelStop(w http.ResponseWriter, r *http.Request) {
+	limitBody(r, w)
+	if s.tunnels == nil {
+		writeError(w, http.StatusNotImplemented, "tunnel control not available")
+		return
+	}
+
+	id := tunnel.TunnelID{
+		Project: r.PathValue("project"),
+		Service: r.PathValue("service"),
+	}
+	if err := s.tunnels.StopTunnel(id); err != nil {
+		writeError(w, tunnelErrorStatus(err), err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
 }
 
 func (s *Server) handleCerts(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/httphatch/hatch/internal/certs"
 	"github.com/httphatch/hatch/internal/health"
 	"github.com/httphatch/hatch/internal/process"
+	"github.com/httphatch/hatch/internal/tunnel"
 )
 
 // DaemonControl allows the API to trigger daemon operations.
@@ -23,6 +24,13 @@ type DaemonControl interface {
 // DashboardShower can show the GUI dashboard window.
 type DashboardShower interface {
 	ShowDashboard()
+}
+
+// TunnelController provides tunnel status and control operations.
+type TunnelController interface {
+	StartTunnel(id tunnel.TunnelID, upstream, tunnelName, token string) error
+	StopTunnel(id tunnel.TunnelID) error
+	Statuses() map[tunnel.TunnelID]tunnel.TunnelStatus
 }
 
 // ProcessController provides process status and control operations.
@@ -40,6 +48,7 @@ type Server struct {
 	dashboard DashboardShower
 	health    *health.Checker
 	processes ProcessController
+	tunnels   TunnelController
 	caPaths   certs.CAPaths
 	version   string
 	startTime time.Time
@@ -53,6 +62,7 @@ type ServerConfig struct {
 	Addr      string
 	Health    *health.Checker
 	Processes ProcessController
+	Tunnels   TunnelController
 	Daemon    DaemonControl
 	Dashboard DashboardShower
 	CAPaths   certs.CAPaths
@@ -69,6 +79,7 @@ func NewServer(cfg ServerConfig) *Server {
 		dashboard: cfg.Dashboard,
 		health:    cfg.Health,
 		processes: cfg.Processes,
+		tunnels:   cfg.Tunnels,
 		caPaths:   cfg.CAPaths,
 		version:   cfg.Version,
 		startTime: cfg.StartTime,
@@ -133,6 +144,9 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/config", s.handleGetConfig)
 	mux.HandleFunc("PUT /api/config", s.handlePutConfig)
 	mux.HandleFunc("GET /api/certs", s.handleCerts)
+	mux.HandleFunc("GET /api/tunnels", s.handleTunnels)
+	mux.HandleFunc("POST /api/tunnels/{project}/{service}/start", requireJSON(s.handleTunnelStart))
+	mux.HandleFunc("POST /api/tunnels/{project}/{service}/stop", requireJSON(s.handleTunnelStop))
 	mux.HandleFunc("POST /api/restart", requireJSON(s.handleRestart))
 	mux.HandleFunc("POST /api/dashboard/show", requireJSON(s.handleShowDashboard))
 }

--- a/internal/caddy/testdata/full.json
+++ b/internal/caddy/testdata/full.json
@@ -66,6 +66,9 @@
                             "Access-Control-Allow-Origin": [
                               "{http.request.header.Origin}"
                             ],
+                            "Access-Control-Allow-Private-Network": [
+                              "true"
+                            ],
                             "Access-Control-Max-Age": [
                               "3600"
                             ],
@@ -101,6 +104,9 @@
                               ],
                               "Access-Control-Allow-Origin": [
                                 "{http.request.header.Origin}"
+                              ],
+                              "Access-Control-Allow-Private-Network": [
+                                "true"
                               ],
                               "Vary": [
                                 "Origin"
@@ -165,6 +171,9 @@
                             "Access-Control-Allow-Origin": [
                               "{http.request.header.Origin}"
                             ],
+                            "Access-Control-Allow-Private-Network": [
+                              "true"
+                            ],
                             "Access-Control-Max-Age": [
                               "3600"
                             ],
@@ -200,6 +209,9 @@
                               ],
                               "Access-Control-Allow-Origin": [
                                 "{http.request.header.Origin}"
+                              ],
+                              "Access-Control-Allow-Private-Network": [
+                                "true"
                               ],
                               "Vary": [
                                 "Origin"
@@ -254,6 +266,9 @@
                             "Access-Control-Allow-Origin": [
                               "{http.request.header.Origin}"
                             ],
+                            "Access-Control-Allow-Private-Network": [
+                              "true"
+                            ],
                             "Access-Control-Max-Age": [
                               "3600"
                             ],
@@ -289,6 +304,9 @@
                               ],
                               "Access-Control-Allow-Origin": [
                                 "{http.request.header.Origin}"
+                              ],
+                              "Access-Control-Allow-Private-Network": [
+                                "true"
                               ],
                               "Vary": [
                                 "Origin"

--- a/internal/caddy/translate.go
+++ b/internal/caddy/translate.go
@@ -140,11 +140,12 @@ func routeTier(info routeInfo) int {
 // requests work between .test subdomains during local development.
 func corsHeaders() map[string][]string {
 	return map[string][]string{
-		"Access-Control-Allow-Origin":      {"{http.request.header.Origin}"},
-		"Access-Control-Allow-Methods":     {"GET, POST, PUT, PATCH, DELETE, OPTIONS"},
-		"Access-Control-Allow-Headers":     {"Authorization, Content-Type, X-Requested-With, Accept, Origin"},
-		"Access-Control-Allow-Credentials": {"true"},
-		"Vary":                             {"Origin"},
+		"Access-Control-Allow-Origin":          {"{http.request.header.Origin}"},
+		"Access-Control-Allow-Methods":         {"GET, POST, PUT, PATCH, DELETE, OPTIONS"},
+		"Access-Control-Allow-Headers":         {"Authorization, Content-Type, X-Requested-With, Accept, Origin"},
+		"Access-Control-Allow-Credentials":     {"true"},
+		"Access-Control-Allow-Private-Network": {"true"},
+		"Vary":                                 {"Origin"},
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -131,6 +131,9 @@ func MergeAllProjectConfigs(cfg *Config) {
 		}
 		proj.Domain = pc.Domain
 		proj.Services = pc.Services
+		if pc.CloudflareToken != "" {
+			proj.CloudflareToken = pc.CloudflareToken
+		}
 		cfg.Projects[name] = proj
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,5 +1,12 @@
 package config
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Config is the top-level Hatch configuration.
 type Config struct {
 	Version  int                `yaml:"version" json:"version"`
@@ -9,34 +16,72 @@ type Config struct {
 
 // Settings holds global Hatch settings.
 type Settings struct {
-	TLD       string `yaml:"tld" json:"tld"`
-	HTTPPort  int    `yaml:"http_port" json:"http_port"`
-	HTTPSPort int    `yaml:"https_port" json:"https_port"`
-	AutoStart bool   `yaml:"auto_start" json:"auto_start"`
-	TrayIcon  bool   `yaml:"tray_icon" json:"tray_icon"`
-	LogLevel  string `yaml:"log_level" json:"log_level"`
+	TLD             string `yaml:"tld" json:"tld"`
+	HTTPPort        int    `yaml:"http_port" json:"http_port"`
+	HTTPSPort       int    `yaml:"https_port" json:"https_port"`
+	AutoStart       bool   `yaml:"auto_start" json:"auto_start"`
+	TrayIcon        bool   `yaml:"tray_icon" json:"tray_icon"`
+	LogLevel        string `yaml:"log_level" json:"log_level"`
+	CloudflareToken string `yaml:"cloudflare_token,omitempty" json:"cloudflare_token,omitempty"`
 }
 
 // Project defines a single project's proxy configuration.
 type Project struct {
-	Domain   string             `yaml:"domain,omitempty" json:"domain"`
-	Path     string             `yaml:"path" json:"path"`
-	Enabled  bool               `yaml:"enabled" json:"enabled"`
-	Services map[string]Service `yaml:"services,omitempty" json:"services"`
+	Domain          string             `yaml:"domain,omitempty" json:"domain"`
+	Path            string             `yaml:"path" json:"path"`
+	Enabled         bool               `yaml:"enabled" json:"enabled"`
+	Services        map[string]Service `yaml:"services,omitempty" json:"services"`
+	CloudflareToken string             `yaml:"cloudflare_token,omitempty" json:"cloudflare_token,omitempty"`
+}
+
+// TunnelValue holds the tunnel configuration for a service.
+// It accepts both boolean and string YAML values.
+type TunnelValue string
+
+// UnmarshalYAML handles both boolean and string YAML values for tunnel config.
+func (t *TunnelValue) UnmarshalYAML(value *yaml.Node) error {
+	if value.Tag == "!!bool" {
+		if value.Value == "true" {
+			*t = "true"
+		}
+		// tunnel: false means no tunnel (leave as zero value "").
+		return nil
+	}
+	*t = TunnelValue(value.Value)
+	return nil
+}
+
+// UnmarshalJSON handles both boolean and string JSON values for tunnel config.
+func (t *TunnelValue) UnmarshalJSON(data []byte) error {
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		if b {
+			*t = "true"
+		}
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("tunnel must be a string or boolean: %w", err)
+	}
+	*t = TunnelValue(s)
+	return nil
 }
 
 // Service defines how a single service is proxied and optionally managed.
 type Service struct {
-	Proxy     string `yaml:"proxy,omitempty" json:"proxy,omitempty"`
-	Command   string `yaml:"command,omitempty" json:"command,omitempty"`
-	Route     string `yaml:"route,omitempty" json:"route,omitempty"`
-	Subdomain string `yaml:"subdomain,omitempty" json:"subdomain,omitempty"`
-	WebSocket bool   `yaml:"websocket,omitempty" json:"websocket,omitempty"`
-	EnvFile   string `yaml:"env_file,omitempty" json:"env_file,omitempty"`
+	Proxy     string      `yaml:"proxy,omitempty" json:"proxy,omitempty"`
+	Command   string      `yaml:"command,omitempty" json:"command,omitempty"`
+	Route     string      `yaml:"route,omitempty" json:"route,omitempty"`
+	Subdomain string      `yaml:"subdomain,omitempty" json:"subdomain,omitempty"`
+	WebSocket bool        `yaml:"websocket,omitempty" json:"websocket,omitempty"`
+	EnvFile   string      `yaml:"env_file,omitempty" json:"env_file,omitempty"`
+	Tunnel    TunnelValue `yaml:"tunnel,omitempty" json:"tunnel,omitempty"`
 }
 
 // ProjectConfig is the schema for a per-project hatch.yml file.
 type ProjectConfig struct {
-	Domain   string             `yaml:"domain"`
-	Services map[string]Service `yaml:"services"`
+	Domain          string             `yaml:"domain"`
+	Services        map[string]Service `yaml:"services"`
+	CloudflareToken string             `yaml:"cloudflare_token,omitempty"`
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -9,6 +9,7 @@ import (
 )
 
 var validHostnameLabel = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+var validTunnelName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,62}$`)
 
 var allowedTLDs = map[string]bool{
 	"test":      true,
@@ -40,7 +41,7 @@ func Validate(cfg Config) []error {
 	// Projects
 	domains := make(map[string]string) // domain -> project name
 	for name, proj := range cfg.Projects {
-		errs = append(errs, validateProject(name, proj, cfg.Settings.TLD, domains)...)
+		errs = append(errs, validateProject(name, proj, cfg.Settings, domains)...)
 	}
 
 	return errs
@@ -72,9 +73,10 @@ func validateSettings(s Settings) []error {
 	return errs
 }
 
-func validateProject(name string, p Project, tld string, domains map[string]string) []error {
+func validateProject(name string, p Project, s Settings, domains map[string]string) []error {
 	var errs []error
 	prefix := fmt.Sprintf("projects.%s", name)
+	tld := s.TLD
 
 	// Domain: valid hostname ending with configured TLD
 	switch {
@@ -98,6 +100,12 @@ func validateProject(name string, p Project, tld string, domains map[string]stri
 		errs = append(errs, fmt.Errorf("%s.path must be an absolute path, got %q", prefix, p.Path))
 	}
 
+	// Resolve Cloudflare token: project-level overrides global.
+	token := s.CloudflareToken
+	if p.CloudflareToken != "" {
+		token = p.CloudflareToken
+	}
+
 	// Services — linked projects (with a Path) may have services defined in
 	// hatch.yml rather than in the central config, so empty services are
 	// allowed when a path is set.
@@ -105,19 +113,32 @@ func validateProject(name string, p Project, tld string, domains map[string]stri
 		errs = append(errs, fmt.Errorf("%s.services must have at least one entry", prefix))
 	}
 	for svcName, svc := range p.Services {
-		errs = append(errs, validateService(prefix, svcName, svc)...)
+		errs = append(errs, validateService(prefix, svcName, svc, token)...)
 	}
 
 	return errs
 }
 
-func validateService(prefix, name string, s Service) []error {
+func validateService(prefix, name string, s Service, token string) []error {
 	var errs []error
 	svcPrefix := fmt.Sprintf("%s.services.%s", prefix, name)
 
 	// At least one of command or proxy is required.
 	if s.Command == "" && s.Proxy == "" {
 		errs = append(errs, fmt.Errorf("%s: command or proxy is required", svcPrefix))
+	}
+
+	// Tunnel validation.
+	if s.Tunnel != "" && s.Proxy == "" {
+		errs = append(errs, fmt.Errorf("%s.tunnel requires proxy to be set", svcPrefix))
+	}
+	if s.Tunnel != "" && s.Tunnel != "true" {
+		if !validTunnelName.MatchString(string(s.Tunnel)) {
+			errs = append(errs, fmt.Errorf("%s.tunnel %q must contain only alphanumeric characters, hyphens, or underscores", svcPrefix, string(s.Tunnel)))
+		}
+		if token == "" {
+			errs = append(errs, fmt.Errorf("%s.tunnel: named tunnel %q requires a cloudflare_token", svcPrefix, string(s.Tunnel)))
+		}
 	}
 
 	// Proxy URL (validated only when set).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/httphatch/hatch/internal/dns"
 	"github.com/httphatch/hatch/internal/health"
 	"github.com/httphatch/hatch/internal/process"
+	"github.com/httphatch/hatch/internal/tunnel"
 )
 
 // Daemon orchestrates all Hatch subsystems as a long-running background process.
@@ -27,6 +29,7 @@ type Daemon struct {
 	dns       *dns.Server
 	health    *health.Checker
 	processes *process.Manager
+	tunnels   *tunnel.Manager
 	watcher   *config.Watcher
 	api       *api.Server
 	pidFile   *os.File
@@ -171,11 +174,28 @@ func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShowe
 	d.processes = procMgr
 	log.Info().Msg("process manager started")
 
+	// Start tunnel manager.
+	stateFile := filepath.Join(config.Dir(), "tunnels.json")
+	tunnelMgr := tunnel.NewManager(stateFile, func(project, service, source, line string) {
+		log.Info().
+			Str("project", project).
+			Str("service", service).
+			Str("source", source).
+			Msg(line)
+		d.outputHub.Write(project, service, source, line)
+	})
+	if err := tunnelMgr.ApplyConfig(cfg); err != nil {
+		log.Warn().Err(err).Msg("failed to apply tunnel config")
+	}
+	d.tunnels = tunnelMgr
+	log.Info().Msg("tunnel manager started")
+
 	// Start API server.
 	apiSrv := api.NewServer(api.ServerConfig{
 		Addr:      "127.0.0.1:42824",
 		Health:    d.health,
 		Processes: d.processes,
+		Tunnels:   d.tunnels,
 		Daemon:    d,
 		Dashboard: dashboard,
 		CAPaths:   d.caPaths,
@@ -262,6 +282,14 @@ func (d *Daemon) Shutdown() error {
 		log.Info().Msg("config watcher stopped")
 	}
 
+	// Tunnel manager (before process manager so tunnels disconnect first).
+	if d.tunnels != nil {
+		if err := d.tunnels.StopAll(); err != nil {
+			errs = append(errs, fmt.Errorf("stop tunnel manager: %w", err))
+		}
+		log.Info().Msg("tunnel manager stopped")
+	}
+
 	// Process manager.
 	if d.processes != nil {
 		if err := d.processes.Stop(); err != nil {
@@ -340,6 +368,12 @@ func (d *Daemon) onConfigReload(cfg config.Config) {
 		}
 	}
 
+	if d.tunnels != nil {
+		if err := d.tunnels.ApplyConfig(cfg); err != nil {
+			log.Error().Err(err).Msg("failed to apply tunnel config")
+		}
+	}
+
 	log.Info().Msg("config reloaded successfully")
 }
 
@@ -359,6 +393,9 @@ func (d *Daemon) shutdownPartial() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		_ = d.api.Shutdown(ctx)
 		cancel()
+	}
+	if d.tunnels != nil {
+		_ = d.tunnels.StopAll()
 	}
 	if d.processes != nil {
 		_ = d.processes.Stop()

--- a/internal/tunnel/find.go
+++ b/internal/tunnel/find.go
@@ -1,0 +1,34 @@
+package tunnel
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// Common install paths for cloudflared on macOS. The daemon runs under
+// launchd which has a minimal $PATH that does not include Homebrew's
+// bin directory, so exec.LookPath alone is not enough.
+var fallbackPaths = []string{
+	"/opt/homebrew/bin/cloudflared",
+	"/usr/local/bin/cloudflared",
+}
+
+// FindCloudflared returns the path to the cloudflared binary.
+func FindCloudflared() (string, error) {
+	path, err := exec.LookPath("cloudflared")
+	if err == nil {
+		return path, nil
+	}
+
+	if runtime.GOOS == "darwin" {
+		for _, p := range fallbackPaths {
+			if _, err := os.Stat(p); err == nil {
+				return p, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("cloudflared not found (install with: brew install cloudflared): %w", err)
+}

--- a/internal/tunnel/manager.go
+++ b/internal/tunnel/manager.go
@@ -1,0 +1,328 @@
+package tunnel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/httphatch/hatch/internal/config"
+)
+
+// TunnelID uniquely identifies a tunnel.
+type TunnelID struct {
+	Project string
+	Service string
+}
+
+func (id TunnelID) String() string {
+	return id.Project + "/" + id.Service
+}
+
+// TunnelStatus holds the current state of a tunnel.
+type TunnelStatus struct {
+	Running   bool      `json:"running"`
+	Starting  bool      `json:"starting"`
+	URL       string    `json:"url"`
+	Type      string    `json:"type"` // "quick" or "named"
+	StartedAt time.Time `json:"started_at"`
+	Error     string    `json:"error,omitempty"`
+}
+
+type managed struct {
+	runner *Runner
+	status TunnelStatus
+	done   <-chan struct{}
+}
+
+// Manager supervises cloudflared tunnel processes.
+type Manager struct {
+	mu        sync.Mutex
+	tunnels   map[TunnelID]*managed
+	stateFile string
+	onOutput  func(project, service, source, line string)
+}
+
+// NewManager creates a new tunnel Manager.
+// stateFile is the path to persist tunnel state (e.g. ~/.hatch/tunnels.json).
+// onOutput, if non-nil, receives cloudflared output lines for logging and streaming.
+func NewManager(stateFile string, onOutput func(project, service, source, line string)) *Manager {
+	return &Manager{
+		tunnels:   make(map[TunnelID]*managed),
+		stateFile: stateFile,
+		onOutput:  onOutput,
+	}
+}
+
+// StartTunnel starts a tunnel for the given service.
+func (m *Manager) StartTunnel(id TunnelID, upstream, tunnelName, token string) error {
+	m.mu.Lock()
+	if t, ok := m.tunnels[id]; ok && (t.status.Running || t.status.Starting) {
+		m.mu.Unlock()
+		if t.status.Starting {
+			return fmt.Errorf("tunnel already starting: %s", id)
+		}
+		return fmt.Errorf("tunnel already running: %s", id)
+	}
+	m.mu.Unlock()
+
+	cfPath, err := FindCloudflared()
+	if err != nil {
+		return err
+	}
+
+	if upstream == "" {
+		return fmt.Errorf("service has no upstream to tunnel")
+	}
+
+	tunnelType := "quick"
+	if tunnelName != "" && tunnelName != "true" {
+		tunnelType = "named"
+	} else {
+		tunnelName = ""
+	}
+
+	// Register as "starting" so the dashboard can show a loading state
+	// while cloudflared is initializing (can take up to 30s for quick tunnels).
+	mgd := &managed{
+		status: TunnelStatus{
+			Starting: true,
+			Type:     tunnelType,
+		},
+	}
+	m.mu.Lock()
+	m.tunnels[id] = mgd
+	m.mu.Unlock()
+
+	runner := &Runner{cfg: RunnerConfig{
+		Upstream:        upstream,
+		TunnelName:      tunnelName,
+		Token:           token,
+		CloudflaredPath: cfPath,
+		OnOutput: func(source, line string) {
+			log.Debug().
+				Str("tunnel", id.String()).
+				Str("source", source).
+				Msg(line)
+			if m.onOutput != nil {
+				m.onOutput(id.Project, id.Service, source, line)
+			}
+		},
+	}}
+
+	if err := runner.Start(); err != nil {
+		m.mu.Lock()
+		delete(m.tunnels, id)
+		m.mu.Unlock()
+		return fmt.Errorf("starting tunnel %s: %w", id, err)
+	}
+
+	m.mu.Lock()
+	mgd.runner = runner
+	mgd.status = TunnelStatus{
+		Running:   true,
+		URL:       runner.URL(),
+		Type:      tunnelType,
+		StartedAt: time.Now(),
+	}
+	mgd.done = runner.Done()
+	m.mu.Unlock()
+
+	m.saveState()
+
+	// Monitor for unexpected exit.
+	go func() {
+		<-mgd.done
+		m.mu.Lock()
+		if current, ok := m.tunnels[id]; ok && current == mgd {
+			current.status.Running = false
+			current.status.Error = "tunnel process exited"
+		}
+		m.mu.Unlock()
+		m.saveState()
+	}()
+
+	return nil
+}
+
+// StopTunnel stops a running tunnel.
+func (m *Manager) StopTunnel(id TunnelID) error {
+	m.mu.Lock()
+	mgd, ok := m.tunnels[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("tunnel not found: %s", id)
+	}
+	if !mgd.status.Running {
+		m.mu.Unlock()
+		return fmt.Errorf("tunnel already stopped: %s", id)
+	}
+	m.mu.Unlock()
+
+	if err := mgd.runner.Stop(); err != nil {
+		return fmt.Errorf("stopping tunnel %s: %w", id, err)
+	}
+
+	m.mu.Lock()
+	delete(m.tunnels, id)
+	m.mu.Unlock()
+
+	m.saveState()
+	return nil
+}
+
+// Statuses returns a snapshot of all tunnel statuses.
+func (m *Manager) Statuses() map[TunnelID]TunnelStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make(map[TunnelID]TunnelStatus, len(m.tunnels))
+	for id, mgd := range m.tunnels {
+		out[id] = mgd.status
+	}
+	return out
+}
+
+// StopAll stops all running tunnels.
+func (m *Manager) StopAll() error {
+	m.mu.Lock()
+	tunnels := make(map[TunnelID]*managed, len(m.tunnels))
+	for k, v := range m.tunnels {
+		tunnels[k] = v
+	}
+	m.mu.Unlock()
+
+	for _, mgd := range tunnels {
+		if mgd.status.Running {
+			_ = mgd.runner.Stop()
+		}
+	}
+
+	m.mu.Lock()
+	m.tunnels = make(map[TunnelID]*managed)
+	m.mu.Unlock()
+
+	m.saveState()
+	return nil
+}
+
+// ApplyConfig reconciles running tunnels with the given config.
+func (m *Manager) ApplyConfig(cfg config.Config) error {
+	desired := m.buildDesired(cfg)
+
+	// Stop tunnels no longer in config.
+	m.mu.Lock()
+	var toStop []TunnelID
+	for id := range m.tunnels {
+		if _, ok := desired[id]; !ok {
+			toStop = append(toStop, id)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, id := range toStop {
+		if err := m.StopTunnel(id); err != nil {
+			log.Warn().Err(err).Str("tunnel", id.String()).Msg("failed to stop removed tunnel")
+		}
+	}
+
+	// Start new tunnels in the background so they don't block
+	// the daemon boot sequence (quick tunnels can take up to 30s
+	// to obtain a URL from cloudflared).
+	for id, want := range desired {
+		m.mu.Lock()
+		_, exists := m.tunnels[id]
+		m.mu.Unlock()
+
+		if exists {
+			continue
+		}
+
+		go func(id TunnelID, want desiredTunnel) {
+			if err := m.StartTunnel(id, want.upstream, want.tunnelName, want.token); err != nil {
+				log.Warn().Err(err).Str("tunnel", id.String()).Msg("failed to start tunnel")
+			}
+		}(id, want)
+	}
+
+	return nil
+}
+
+type desiredTunnel struct {
+	upstream   string
+	tunnelName string
+	token      string
+}
+
+func (m *Manager) buildDesired(cfg config.Config) map[TunnelID]desiredTunnel {
+	desired := make(map[TunnelID]desiredTunnel)
+	for projName, proj := range cfg.Projects {
+		if !proj.Enabled {
+			continue
+		}
+		for svcName, svc := range proj.Services {
+			tunnelVal := string(svc.Tunnel)
+			if tunnelVal == "" {
+				continue
+			}
+			if svc.Proxy == "" {
+				continue
+			}
+
+			token := proj.CloudflareToken
+			if token == "" {
+				token = cfg.Settings.CloudflareToken
+			}
+
+			desired[TunnelID{Project: projName, Service: svcName}] = desiredTunnel{
+				upstream:   svc.Proxy,
+				tunnelName: tunnelVal,
+				token:      token,
+			}
+		}
+	}
+	return desired
+}
+
+type persistedTunnel struct {
+	URL       string `json:"url"`
+	Type      string `json:"type"`
+	StartedAt string `json:"started_at"`
+}
+
+// saveState persists running tunnel info to disk for CLI status display.
+// This is informational only; the manager does not restore state on startup.
+func (m *Manager) saveState() {
+	m.mu.Lock()
+	state := make(map[string]persistedTunnel)
+	for id, mgd := range m.tunnels {
+		if mgd.status.Running {
+			state[id.String()] = persistedTunnel{
+				URL:       mgd.status.URL,
+				Type:      mgd.status.Type,
+				StartedAt: mgd.status.StartedAt.Format(time.RFC3339),
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to marshal tunnel state")
+		return
+	}
+
+	dir := filepath.Dir(m.stateFile)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Warn().Err(err).Msg("failed to create tunnel state directory")
+		return
+	}
+
+	if err := os.WriteFile(m.stateFile, data, 0600); err != nil {
+		log.Warn().Err(err).Msg("failed to write tunnel state")
+	}
+}

--- a/internal/tunnel/manager_test.go
+++ b/internal/tunnel/manager_test.go
@@ -1,0 +1,111 @@
+package tunnel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestQuickTunnelURLParsing(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "mock-cloudflared")
+	err := os.WriteFile(script, []byte(`#!/bin/sh
+echo "some startup output"
+echo "https://test-abc-123.trycloudflare.com"
+sleep 60
+`), 0755)
+	if err != nil {
+		t.Fatalf("writing mock script: %v", err)
+	}
+
+	stateFile := filepath.Join(dir, "tunnels.json")
+	mgr := NewManager(stateFile, nil)
+
+	id := TunnelID{Project: "myapp", Service: "web"}
+
+	runner := &Runner{cfg: RunnerConfig{
+		Upstream:        "http://localhost:3000",
+		CloudflaredPath: script,
+	}}
+
+	if err := runner.Start(); err != nil {
+		t.Fatalf("starting runner: %v", err)
+	}
+
+	url := runner.URL()
+	if url != "https://test-abc-123.trycloudflare.com" {
+		t.Errorf("expected trycloudflare URL, got %q", url)
+	}
+
+	if err := runner.Stop(); err != nil {
+		t.Errorf("stopping runner: %v", err)
+	}
+
+	statuses := mgr.Statuses()
+	if len(statuses) != 0 {
+		t.Errorf("expected 0 statuses, got %d", len(statuses))
+	}
+
+	_ = id
+}
+
+func TestManagerStartStop(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "mock-cloudflared")
+	err := os.WriteFile(script, []byte(`#!/bin/sh
+echo "https://test-xyz.trycloudflare.com" >&2
+sleep 60
+`), 0755)
+	if err != nil {
+		t.Fatalf("writing mock script: %v", err)
+	}
+
+	stateFile := filepath.Join(dir, "tunnels.json")
+	mgr := NewManager(stateFile, nil)
+
+	id := TunnelID{Project: "testproj", Service: "web"}
+
+	runner := &Runner{cfg: RunnerConfig{
+		Upstream:        "http://localhost:8080",
+		CloudflaredPath: script,
+	}}
+
+	if err := runner.Start(); err != nil {
+		t.Fatalf("starting runner: %v", err)
+	}
+
+	url := runner.URL()
+	if url != "https://test-xyz.trycloudflare.com" {
+		t.Errorf("expected trycloudflare URL from stderr, got %q", url)
+	}
+
+	select {
+	case <-runner.Done():
+		t.Error("runner should still be running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := runner.Stop(); err != nil {
+		t.Errorf("stopping runner: %v", err)
+	}
+
+	select {
+	case <-runner.Done():
+	case <-time.After(5 * time.Second):
+		t.Error("runner did not stop in time")
+	}
+
+	_ = id
+	_ = mgr
+}
+
+func TestManagerStopAll(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, "tunnels.json")
+	mgr := NewManager(stateFile, nil)
+
+	if err := mgr.StopAll(); err != nil {
+		t.Errorf("StopAll on empty manager: %v", err)
+	}
+}

--- a/internal/tunnel/rewrite_proxy.go
+++ b/internal/tunnel/rewrite_proxy.go
@@ -1,0 +1,189 @@
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// maxRewriteBody is the maximum HTML response body size the rewrite proxy
+// will buffer. Responses larger than this pass through without rewriting.
+const maxRewriteBody = 10 << 20 // 10 MB
+
+// localhostRe matches absolute http/ws URLs pointing to any localhost
+// address on any port. Used to strip these prefixes from HTML responses
+// so paths become relative (e.g. "/@vite/client").
+var localhostRe = regexp.MustCompile(
+	`(?:https?|wss?)://(?:localhost|127\.0\.0\.1|\[::1\]):\d+`,
+)
+
+// rewriteProxy sits between cloudflared and the upstream app server.
+// It does two things:
+//  1. Rewrites absolute localhost URLs in HTML responses to relative paths,
+//     preventing PNA (Private Network Access) browser blocks.
+//  2. Falls back to a discovered dev server (e.g. Vite) for asset requests
+//     that 404 on the upstream. The dev server address is extracted from
+//     localhost URLs found in the first HTML response.
+type rewriteProxy struct {
+	server   *http.Server
+	listener net.Listener
+	addr     string
+}
+
+// startRewriteProxy starts a local HTTP proxy that forwards requests to
+// upstream, rewrites HTML responses, and falls back to a discovered dev
+// server for 404'd assets. Returns the proxy's listen address for cloudflared.
+func startRewriteProxy(upstream string) (*rewriteProxy, error) {
+	target, err := url.Parse(upstream)
+	if err != nil {
+		return nil, fmt.Errorf("parsing upstream URL: %w", err)
+	}
+
+	ft := &devFallbackTransport{
+		inner:    http.DefaultTransport,
+		upstream: target,
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.Transport = ft
+	proxy.ModifyResponse = func(resp *http.Response) error {
+		ct := resp.Header.Get("Content-Type")
+		if !strings.Contains(ct, "text/html") {
+			return nil
+		}
+		if resp.Header.Get("Content-Encoding") != "" {
+			return nil
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxRewriteBody))
+		_ = resp.Body.Close()
+		if err != nil {
+			return fmt.Errorf("reading response body: %w", err)
+		}
+
+		// Extract dev server address from localhost URLs before rewriting.
+		// In setups like Laravel+Vite, the HTML from the app server contains
+		// script tags pointing to the Vite dev server on a different port.
+		ft.discoverDevServer(body, target)
+
+		body = localhostRe.ReplaceAll(body, nil)
+
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		resp.ContentLength = int64(len(body))
+		resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("creating listener: %w", err)
+	}
+
+	srv := &http.Server{Handler: proxy}
+	go func() { _ = srv.Serve(listener) }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = listener.Close()
+		return nil, fmt.Errorf("listener address is not TCP")
+	}
+
+	addr := fmt.Sprintf("http://127.0.0.1:%d", tcpAddr.Port)
+	return &rewriteProxy{
+		server:   srv,
+		listener: listener,
+		addr:     addr,
+	}, nil
+}
+
+func (p *rewriteProxy) Close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = p.server.Shutdown(ctx)
+	_ = p.listener.Close()
+}
+
+// devFallbackTransport wraps an http.RoundTripper and retries GET requests
+// against a discovered dev server when the upstream returns 404. This handles
+// setups where the app server (e.g. Laravel) serves HTML but a separate dev
+// server (e.g. Vite on a different port) serves JS/CSS assets.
+type devFallbackTransport struct {
+	inner    http.RoundTripper
+	upstream *url.URL
+	devAddr  atomic.Value // stores *url.URL or nil
+}
+
+// discoverDevServer scans HTML bytes for localhost URLs and records the first
+// one whose port differs from the upstream. This is the dev server (e.g. Vite).
+func (t *devFallbackTransport) discoverDevServer(html []byte, upstream *url.URL) {
+	if t.devAddr.Load() != nil {
+		return // already discovered
+	}
+
+	matches := localhostRe.FindAll(html, -1)
+	for _, match := range matches {
+		u, err := url.Parse(string(match))
+		if err != nil {
+			continue
+		}
+		if u.Port() != upstream.Port() {
+			t.devAddr.Store(u)
+			return
+		}
+	}
+}
+
+func (t *devFallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only retry GETs. POST/PUT/etc should not be retried.
+	if req.Method != http.MethodGet {
+		return resp, nil
+	}
+
+	// Decide whether to retry against the dev server:
+	// - 404: asset not found on upstream (e.g. Vite files served by Laravel)
+	// - WebSocket upgrade that didn't get 101: the upstream (e.g. Laravel)
+	//   doesn't handle WebSocket, but the dev server (Vite HMR) does.
+	shouldRetry := resp.StatusCode == http.StatusNotFound
+	if !shouldRetry && isWebSocketUpgrade(req) && resp.StatusCode != http.StatusSwitchingProtocols {
+		shouldRetry = true
+	}
+
+	if !shouldRetry {
+		return resp, nil
+	}
+
+	dev, _ := t.devAddr.Load().(*url.URL)
+	if dev == nil {
+		return resp, nil
+	}
+
+	// The upstream can't serve this request and we know about a dev server.
+	// Close the response and retry against the dev server.
+	_ = resp.Body.Close()
+
+	retry := req.Clone(req.Context())
+	retry.URL.Scheme = dev.Scheme
+	retry.URL.Host = dev.Host
+	retry.Host = dev.Host
+	return t.inner.RoundTrip(retry)
+}
+
+func isWebSocketUpgrade(req *http.Request) bool {
+	return strings.EqualFold(req.Header.Get("Connection"), "upgrade") &&
+		strings.EqualFold(req.Header.Get("Upgrade"), "websocket")
+}

--- a/internal/tunnel/rewrite_proxy_test.go
+++ b/internal/tunnel/rewrite_proxy_test.go
@@ -1,0 +1,288 @@
+package tunnel
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestRewriteProxy(t *testing.T) {
+	// Simulate a Laravel+Vite setup: app server returns HTML with absolute
+	// URLs pointing to a separate Vite dev server on a different port.
+	var vitePort string
+	viteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = fmt.Fprintf(w, `console.log("vite asset: %s")`, r.URL.Path)
+	}))
+	defer viteServer.Close()
+
+	viteURL, _ := url.Parse(viteServer.URL)
+	vitePort = viteURL.Port()
+
+	appServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprintf(w, `<!doctype html>
+<html>
+<head>
+<script type="module" src="http://127.0.0.1:%s/@vite/client"></script>
+<script type="module" src="http://127.0.0.1:%s/resources/js/app.tsx"></script>
+</head>
+<body><div id="root"></div></body>
+</html>`, vitePort, vitePort)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer appServer.Close()
+
+	proxy, err := startRewriteProxy(appServer.URL)
+	if err != nil {
+		t.Fatalf("starting proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	// First request: HTML page. URLs should be rewritten to relative paths
+	// and the dev server should be discovered.
+	resp, err := http.Get(proxy.addr + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	got := string(body)
+
+	if !strings.Contains(got, `src="/@vite/client"`) {
+		t.Errorf("expected relative /@vite/client in HTML, got:\n%s", got)
+	}
+	if !strings.Contains(got, `src="/resources/js/app.tsx"`) {
+		t.Errorf("expected relative /resources/js/app.tsx in HTML, got:\n%s", got)
+	}
+	if strings.Contains(got, "[::1]:") {
+		t.Errorf("HTML still contains [::1] reference:\n%s", got)
+	}
+
+	// Second request: asset that 404s on app server. Should fall back to
+	// the discovered Vite dev server.
+	resp, err = http.Get(proxy.addr + "/@vite/client")
+	if err != nil {
+		t.Fatalf("GET /@vite/client: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 for /@vite/client, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "vite asset: /@vite/client") {
+		t.Errorf("expected vite asset content, got: %s", body)
+	}
+
+	// Third request: another asset path.
+	resp, err = http.Get(proxy.addr + "/resources/js/app.tsx")
+	if err != nil {
+		t.Fatalf("GET /resources/js/app.tsx: %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 for /resources/js/app.tsx, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "vite asset: /resources/js/app.tsx") {
+		t.Errorf("expected vite asset content, got: %s", body)
+	}
+}
+
+func TestRewriteProxyWebSocketFallback(t *testing.T) {
+	// Vite's HMR WebSocket connects to the page origin (tunnel URL).
+	// The upstream (Laravel) doesn't handle WebSocket, so the proxy should
+	// fall back to the discovered dev server (Vite).
+	var vitePort string
+	viteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a successful WebSocket upgrade check. A real test would
+		// need a full WebSocket server, but we just verify the request
+		// reaches the dev server by returning 200.
+		if r.Header.Get("Upgrade") == "websocket" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ws-from-vite"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer viteServer.Close()
+
+	viteURL, _ := url.Parse(viteServer.URL)
+	vitePort = viteURL.Port()
+
+	appServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" && r.Header.Get("Upgrade") == "" {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprintf(w, `<script src="http://127.0.0.1:%s/@vite/client"></script>`, vitePort)
+			return
+		}
+		// Laravel returns 200 HTML for WebSocket requests (it doesn't know about WS).
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html>not found</html>"))
+	}))
+	defer appServer.Close()
+
+	proxy, err := startRewriteProxy(appServer.URL)
+	if err != nil {
+		t.Fatalf("starting proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	// Load HTML to discover the dev server.
+	resp, err := http.Get(proxy.addr + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Simulate a WebSocket upgrade request. The upstream returns 200 (not 101),
+	// so the fallback should retry against the Vite dev server.
+	req, _ := http.NewRequest("GET", proxy.addr+"/?token=abc", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("WebSocket request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if !strings.Contains(string(body), "ws-from-vite") {
+		t.Errorf("WebSocket request did not reach dev server, got status %d body: %s",
+			resp.StatusCode, body)
+	}
+}
+
+func TestRewriteProxyNonHTML(t *testing.T) {
+	var port string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = fmt.Fprintf(w, `const url = "http://localhost:%s/api"`, port)
+	}))
+	defer upstream.Close()
+
+	u, _ := url.Parse(upstream.URL)
+	port = u.Port()
+
+	proxy, err := startRewriteProxy(upstream.URL)
+	if err != nil {
+		t.Fatalf("starting proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	resp, err := http.Get(proxy.addr + "/test.js")
+	if err != nil {
+		t.Fatalf("GET proxy: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	want := fmt.Sprintf("http://localhost:%s/api", port)
+	if !strings.Contains(got, want) {
+		t.Errorf("non-HTML response was rewritten, got:\n%s", got)
+	}
+}
+
+func TestRewriteProxySamePort(t *testing.T) {
+	// When all localhost URLs use the same port as the upstream (e.g. plain
+	// Vite without Laravel), no dev server fallback is needed. Assets are
+	// served directly by the upstream.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			u, _ := url.Parse(r.Host)
+			_ = u
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = fmt.Fprintf(w, `<script src="http://localhost:%s/@vite/client"></script>`,
+				strings.Split(r.Host, ":")[1])
+			return
+		}
+		if r.URL.Path == "/@vite/client" {
+			w.Header().Set("Content-Type", "application/javascript")
+			_, _ = w.Write([]byte(`console.log("vite")`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	proxy, err := startRewriteProxy(upstream.URL)
+	if err != nil {
+		t.Fatalf("starting proxy: %v", err)
+	}
+	defer proxy.Close()
+
+	// Load HTML to trigger rewriting.
+	resp, err := http.Get(proxy.addr + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Asset request should succeed directly from upstream (no fallback needed).
+	resp, err = http.Get(proxy.addr + "/@vite/client")
+	if err != nil {
+		t.Fatalf("GET /@vite/client: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "vite") {
+		t.Errorf("expected vite content, got: %s", body)
+	}
+}
+
+func TestLocalhostRegex(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{
+			input: `<script src="http://localhost:3000/@vite/client"></script>`,
+			want:  `<script src="/@vite/client"></script>`,
+		},
+		{
+			input: `<script src="http://[::1]:5173/resources/js/app.tsx"></script>`,
+			want:  `<script src="/resources/js/app.tsx"></script>`,
+		},
+		{
+			input: `<script src="http://127.0.0.1:8080/main.js"></script>`,
+			want:  `<script src="/main.js"></script>`,
+		},
+		{
+			input: `new WebSocket("ws://localhost:3000/ws")`,
+			want:  `new WebSocket("/ws")`,
+		},
+		{
+			input: `<script src="https://cdn.example.com/lib.js"></script>`,
+			want:  `<script src="https://cdn.example.com/lib.js"></script>`,
+		},
+		{
+			input: `<script src="/already-relative.js"></script>`,
+			want:  `<script src="/already-relative.js"></script>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := string(localhostRe.ReplaceAll([]byte(tt.input), nil))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tunnel/runner.go
+++ b/internal/tunnel/runner.go
@@ -1,0 +1,216 @@
+package tunnel
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	stopTimeout  = 5 * time.Second
+	readyTimeout = 30 * time.Second
+)
+
+var trycloudflareRe = regexp.MustCompile(`https://[a-zA-Z0-9-]+\.trycloudflare\.com`)
+
+// RunnerConfig holds configuration for a tunnel runner.
+type RunnerConfig struct {
+	// Upstream is the local address to tunnel to (e.g. "http://localhost:3000").
+	Upstream string
+	// TunnelName is the named tunnel ID. Empty for quick tunnels.
+	TunnelName string
+	// Token is the Cloudflare API token for named tunnels.
+	Token string
+	// CloudflaredPath is the path to the cloudflared binary.
+	CloudflaredPath string
+	// OnOutput receives output lines from cloudflared.
+	OnOutput func(source, line string)
+}
+
+// IsQuick returns true if this is a quick tunnel (no tunnel name).
+func (cfg RunnerConfig) IsQuick() bool {
+	return cfg.TunnelName == ""
+}
+
+// Runner manages the lifecycle of a single cloudflared tunnel process.
+type Runner struct {
+	cfg   RunnerConfig
+	cmd   *exec.Cmd
+	proxy *rewriteProxy
+	done  chan struct{}
+	err   error
+	url   string
+	mu    sync.Mutex
+}
+
+// Start launches the cloudflared process.
+// For quick tunnels, it blocks until the tunnel URL is discovered or times out.
+func (r *Runner) Start() error {
+	r.mu.Lock()
+
+	// For quick tunnels, start a rewrite proxy that strips absolute localhost
+	// URLs from HTML responses. This prevents PNA (Private Network Access)
+	// errors when frameworks like Vite inject absolute localhost script tags.
+	if r.cfg.IsQuick() {
+		proxy, err := startRewriteProxy(r.cfg.Upstream)
+		if err != nil {
+			r.mu.Unlock()
+			return fmt.Errorf("starting rewrite proxy: %w", err)
+		}
+		r.proxy = proxy
+	}
+
+	cfUpstream := r.cfg.Upstream
+	if r.proxy != nil {
+		cfUpstream = r.proxy.addr
+	}
+
+	var cmd *exec.Cmd
+	if r.cfg.IsQuick() {
+		cmd = exec.Command(r.cfg.CloudflaredPath, "tunnel", "--url", cfUpstream)
+	} else {
+		cmd = exec.Command(r.cfg.CloudflaredPath, "tunnel", "run", r.cfg.TunnelName)
+		// Pass token via environment to avoid exposing it in process args.
+		cmd.Env = append(os.Environ(), "TUNNEL_TOKEN="+r.cfg.Token)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	closeProxy := func() {
+		if r.proxy != nil {
+			r.proxy.Close()
+			r.proxy = nil
+		}
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		closeProxy()
+		r.mu.Unlock()
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		closeProxy()
+		r.mu.Unlock()
+		return fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		closeProxy()
+		r.mu.Unlock()
+		return fmt.Errorf("start cloudflared: %w", err)
+	}
+
+	r.cmd = cmd
+	r.done = make(chan struct{})
+	done := r.done
+
+	urlFound := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	scanOutput := func(scanner *bufio.Scanner, source string) {
+		defer wg.Done()
+		for scanner.Scan() {
+			line := scanner.Text()
+			if r.cfg.OnOutput != nil {
+				r.cfg.OnOutput(source, line)
+			}
+			if r.cfg.IsQuick() {
+				if match := trycloudflareRe.FindString(line); match != "" {
+					select {
+					case urlFound <- match:
+					default:
+					}
+				}
+			}
+		}
+	}
+
+	go scanOutput(bufio.NewScanner(stdout), "stdout")
+	go scanOutput(bufio.NewScanner(stderr), "stderr")
+
+	go func() {
+		wg.Wait()
+		r.mu.Lock()
+		r.err = cmd.Wait()
+		r.mu.Unlock()
+		close(done)
+	}()
+
+	// Release the lock before waiting on channels.
+	r.mu.Unlock()
+
+	if r.cfg.IsQuick() {
+		select {
+		case url := <-urlFound:
+			r.mu.Lock()
+			r.url = url
+			r.mu.Unlock()
+		case <-done:
+			r.mu.Lock()
+			closeProxy()
+			r.mu.Unlock()
+			return fmt.Errorf("cloudflared exited before providing tunnel URL")
+		case <-time.After(readyTimeout):
+			_ = r.Stop()
+			return fmt.Errorf("timed out waiting for tunnel URL after %s", readyTimeout)
+		}
+	}
+
+	return nil
+}
+
+// Stop sends SIGTERM to the process group, waits up to 5 seconds,
+// then sends SIGKILL if still running.
+func (r *Runner) Stop() error {
+	r.mu.Lock()
+	cmd := r.cmd
+	done := r.done
+	r.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil || done == nil {
+		return nil
+	}
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		return nil
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+
+	select {
+	case <-done:
+	case <-time.After(stopTimeout):
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		<-done
+	}
+
+	r.mu.Lock()
+	if r.proxy != nil {
+		r.proxy.Close()
+		r.proxy = nil
+	}
+	r.mu.Unlock()
+
+	return nil
+}
+
+// Done returns a channel that is closed when the process exits.
+func (r *Runner) Done() <-chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.done
+}
+
+// URL returns the tunnel URL.
+func (r *Runner) URL() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.url
+}


### PR DESCRIPTION
## Summary

Closes #25.

- Expose local services via Cloudflare Tunnels: quick tunnels (no account, temporary URL) and named tunnels (persistent domain, requires token)
- Rewrite proxy between cloudflared and upstream handles Vite/HMR compatibility: strips absolute localhost URLs from HTML, discovers secondary dev servers, falls back to them for 404'd assets and WebSocket upgrades
- CLI commands: `hatch tunnel start/stop/status`
- Dashboard controls with loading state, clickable URL, error feedback
- Config-driven tunnels via `tunnel` field on services, `cloudflare_token` on settings/projects
- Async tunnel startup so daemon boot is not blocked
- Full documentation across guide, reference, and architecture docs

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `make build` succeeds
- [x] `cd frontend && npm run build` succeeds
- [x] Manual testing: quick tunnel with Laravel+Vite, page content loads, HMR WebSocket connects through tunnel