### PR TITLE
Fix SSE log stream and startup error reporting

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/httphatch/hatch/internal/api"
 )
 
 var appCmd = &cobra.Command{
@@ -13,7 +15,7 @@ var appCmd = &cobra.Command{
 	Short: "Open the Hatch dashboard",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		client := &http.Client{Timeout: 5 * time.Second}
-		resp, err := client.Post("http://127.0.0.1:42824/api/dashboard/show", "application/json", nil)
+		resp, err := client.Post("http://"+api.DefaultAddr+"/api/dashboard/show", "application/json", nil)
 		if err != nil {
 			return fmt.Errorf("daemon not running — start with: hatch up")
 		}

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+
+	"github.com/httphatch/hatch/internal/api"
 )
 
-const daemonBaseURL = "http://127.0.0.1:42824"
+var daemonBaseURL = "http://" + api.DefaultAddr
 
 var processCmd = &cobra.Command{
 	Use:   "process",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,12 +1,16 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/httphatch/hatch/internal/api"
 	"github.com/httphatch/hatch/internal/certs"
 	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/daemon"
@@ -77,6 +81,17 @@ func runUp() error {
 		}
 	}
 
+	// Pre-flight: catch port conflicts before loading the plist so the error
+	// is visible in the terminal. The daemon performs the same check at startup.
+	for _, port := range []int{cfg.Settings.HTTPPort, cfg.Settings.HTTPSPort} {
+		info, err := daemon.CheckPort(port)
+		if err != nil {
+			log.Warn().Err(err).Int("port", port).Msg("could not check port availability")
+		} else if info != nil {
+			return fmt.Errorf("port %d is already in use by %s; stop that process first", port, info)
+		}
+	}
+
 	// Build launchd config and install plist.
 	launchdCfg, err := daemon.DefaultLaunchdConfig(cfg.Settings.AutoStart)
 	if err != nil {
@@ -93,8 +108,41 @@ func runUp() error {
 		return fmt.Errorf("load plist: %w", err)
 	}
 
+	// Verify the daemon actually started by polling the API.
+	if err := waitForDaemon(); err != nil {
+		return fmt.Errorf("daemon failed to start; check logs with: hatch logs")
+	}
+
 	fmt.Printf("%s started\n", color.New(color.FgCyan, color.Bold).Sprint("Hatch"))
 	return nil
+}
+
+// waitForDaemon polls the daemon API until it responds or the timeout expires.
+func waitForDaemon() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := &http.Client{}
+	url := "http://" + api.DefaultAddr + "/api/status"
+
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("creating request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for daemon")
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
 }
 
 func init() {

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -46,23 +46,33 @@ hatch doctor    # check "Root CA trusted" status
 
 ### Port Conflicts
 
-**Symptoms:** `hatch up` fails or `hatch doctor` reports ports unavailable.
-
-**Diagnosis:**
-```bash
-# Check what's using port 80 or 443
-sudo lsof -i :80
-sudo lsof -i :443
-```
+**Symptoms:** `hatch up` fails with a message like `port 80 is already in use by nginx (PID 1234); stop that process first`. Or `hatch doctor` reports ports unavailable.
 
 **Fixes:**
-- Stop the conflicting process (Apache, Nginx, another proxy)
+- Stop the process named in the error, then run `hatch up` again
 - Or change Hatch's ports in `~/.hatch/config.yml`:
   ```yaml
   settings:
     http_port: 8080
     https_port: 8443
   ```
+
+**Manual diagnosis** (if needed):
+```bash
+sudo lsof -i :80
+sudo lsof -i :443
+```
+
+### Daemon Failed to Start
+
+**Symptoms:** `hatch up` prints `daemon failed to start; check logs with: hatch logs` and exits.
+
+The daemon process was launched but did not respond within 5 seconds.
+
+**Fixes:**
+- Run `hatch logs` to see what went wrong
+- Run `hatch doctor` to check for port conflicts or config errors
+- If logs show a port conflict, stop the conflicting process and run `hatch up` again
 
 ### Stale PID File
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -57,7 +57,7 @@ This makes it easy to understand complex multi-service setups at a glance.
 
 ### Log Viewer
 
-The log viewer streams daemon logs in real time via server-sent events. Each entry shows:
+The log viewer streams daemon logs in real time via server-sent events. When you open the panel, it pre-fills with up to 200 recent log entries so you have immediate context. Each entry shows:
 
 - Timestamp
 - Log level

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,9 @@ import (
 	"github.com/httphatch/hatch/internal/tunnel"
 )
 
+// DefaultAddr is the default listen address for the API server.
+const DefaultAddr = "127.0.0.1:42824"
+
 // DaemonControl allows the API to trigger daemon operations.
 type DaemonControl interface {
 	ReloadConfig() error

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -2,11 +2,20 @@ package api
 
 import "sync"
 
+const logBufferSize = 200
+
+// logChannelHeadroom is extra channel capacity beyond logBufferSize so that
+// Subscribe can replay the full buffer without blocking while concurrent
+// writes land in the headroom slots.
+const logChannelHeadroom = 64
+
 // LogHub is a fan-out writer that distributes log output to SSE subscribers.
-// It implements io.Writer so it plugs into zerolog.MultiLevelWriter.
+// It implements io.Writer so it plugs into the zerolog writer chain. A ring
+// buffer of recent entries is kept so new subscribers receive history.
 type LogHub struct {
-	mu          sync.RWMutex
+	mu          sync.Mutex
 	subscribers map[chan []byte]struct{}
+	buffer      [][]byte
 }
 
 // NewLogHub creates a new LogHub.
@@ -16,15 +25,23 @@ func NewLogHub() *LogHub {
 	}
 }
 
-// Write sends a copy of p to every subscriber. It never returns an error
-// so it won't break the zerolog writer chain.
+// Write sends a copy of p to every subscriber and appends it to the ring
+// buffer. It never returns an error so it won't break the writer chain.
 func (h *LogHub) Write(p []byte) (int, error) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	msg := make([]byte, len(p))
+	copy(msg, p)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.buffer = append(h.buffer, msg)
+	if len(h.buffer) > logBufferSize {
+		trimmed := make([][]byte, logBufferSize)
+		copy(trimmed, h.buffer[len(h.buffer)-logBufferSize:])
+		h.buffer = trimmed
+	}
 
 	for ch := range h.subscribers {
-		msg := make([]byte, len(p))
-		copy(msg, p)
 		select {
 		case ch <- msg:
 		default:
@@ -34,12 +51,21 @@ func (h *LogHub) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// Subscribe returns a channel that receives log messages and a cleanup
-// function that must be called when the subscriber is done.
+// Subscribe returns a channel that receives log messages (pre-filled with
+// buffered history) and a cleanup function that must be called when the
+// subscriber is done.
 func (h *LogHub) Subscribe() (<-chan []byte, func()) {
-	ch := make(chan []byte, 64)
+	// Channel capacity: logBufferSize for the history replay plus
+	// logChannelHeadroom for concurrent writes during replay. The buffer
+	// holds at most logBufferSize entries, so the history sends never block.
+	ch := make(chan []byte, logBufferSize+logChannelHeadroom)
 
 	h.mu.Lock()
+
+	for _, msg := range h.buffer {
+		ch <- msg
+	}
+
 	h.subscribers[ch] = struct{}{}
 	h.mu.Unlock()
 

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestLogHub_WriteAndSubscribe(t *testing.T) {
+	hub := NewLogHub()
+
+	ch, cleanup := hub.Subscribe()
+	defer cleanup()
+
+	_, _ = hub.Write([]byte(`{"level":"info","msg":"hello"}`))
+	_, _ = hub.Write([]byte(`{"level":"error","msg":"oops"}`))
+
+	select {
+	case msg := <-ch:
+		if string(msg) != `{"level":"info","msg":"hello"}` {
+			t.Errorf("first message: got %q", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first message")
+	}
+
+	select {
+	case msg := <-ch:
+		if string(msg) != `{"level":"error","msg":"oops"}` {
+			t.Errorf("second message: got %q", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second message")
+	}
+}
+
+func TestLogHub_Buffer(t *testing.T) {
+	hub := NewLogHub()
+
+	_, _ = hub.Write([]byte("line 1"))
+	_, _ = hub.Write([]byte("line 2"))
+	_, _ = hub.Write([]byte("line 3"))
+
+	ch, cleanup := hub.Subscribe()
+	defer cleanup()
+
+	var msgs []string
+	for i := 0; i < 3; i++ {
+		select {
+		case msg := <-ch:
+			msgs = append(msgs, string(msg))
+		case <-time.After(time.Second):
+			t.Fatalf("timed out after %d messages", i)
+		}
+	}
+
+	if msgs[0] != "line 1" {
+		t.Errorf("first buffered message: got %q", msgs[0])
+	}
+	if msgs[2] != "line 3" {
+		t.Errorf("last buffered message: got %q", msgs[2])
+	}
+}
+
+func TestLogHub_BufferOverflow(t *testing.T) {
+	hub := NewLogHub()
+
+	for i := 0; i < logBufferSize+50; i++ {
+		fmt.Fprintf(hub, "line %d", i)
+	}
+
+	ch, cleanup := hub.Subscribe()
+	defer cleanup()
+
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		case <-time.After(100 * time.Millisecond):
+			if count != logBufferSize {
+				t.Errorf("expected %d buffered messages, got %d", logBufferSize, count)
+			}
+			return
+		}
+	}
+}
+
+func TestLogHub_SlowSubscriber(t *testing.T) {
+	hub := NewLogHub()
+
+	ch, cleanup := hub.Subscribe()
+	defer cleanup()
+
+	// Fill channel beyond capacity; Write should not block.
+	for i := 0; i < logBufferSize+logChannelHeadroom+100; i++ {
+		fmt.Fprintf(hub, "line %d", i)
+	}
+
+	// Drain whatever arrived.
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		case <-time.After(100 * time.Millisecond):
+			if count == 0 {
+				t.Error("expected at least some messages")
+			}
+			if count > logBufferSize+logChannelHeadroom {
+				t.Errorf("got %d messages, expected at most %d", count, logBufferSize+logChannelHeadroom)
+			}
+			return
+		}
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -192,7 +192,7 @@ func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShowe
 
 	// Start API server.
 	apiSrv := api.NewServer(api.ServerConfig{
-		Addr:      "127.0.0.1:42824",
+		Addr:      api.DefaultAddr,
 		Health:    d.health,
 		Processes: d.processes,
 		Tunnels:   d.tunnels,
@@ -209,7 +209,7 @@ func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShowe
 		return fmt.Errorf("start api server: %w", err)
 	}
 	d.api = apiSrv
-	log.Info().Str("addr", "127.0.0.1:42824").Msg("api server started")
+	log.Info().Str("addr", api.DefaultAddr).Msg("api server started")
 
 	// Start config watcher.
 	watcher, err := config.NewWatcher(d.cfg, d.onConfigReload)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -60,24 +61,26 @@ func Setup(cfg Config) (*Writer, error) {
 	// Set zerolog global logger to write JSON to lumberjack (and optional extra writer).
 	var w io.Writer = lj
 	if cfg.ExtraWriter != nil {
-		w = zerolog.MultiLevelWriter(lj, cfg.ExtraWriter)
+		w = io.MultiWriter(lj, cfg.ExtraWriter)
 	}
 	log.Logger = zerolog.New(w).Level(parseLevel(cfg.Level)).With().Timestamp().Logger()
 
-	// Capture os.Stderr via os.Pipe so Caddy's stderr output reaches lumberjack.
+	// Capture os.Stderr via os.Pipe so Caddy's stderr output reaches the
+	// same combined writer, ensuring Caddy logs appear in both the file and
+	// the SSE log hub.
 	pr, pw, err := os.Pipe()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating stderr pipe: %w", err)
 	}
 
 	origStderr := os.Stderr
 	os.Stderr = pw
 
 	done := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(lj, pr)
+	go func(dst io.Writer) {
+		_, _ = io.Copy(dst, pr)
 		close(done)
-	}()
+	}(w)
 
 	return &Writer{
 		lj:         lj,

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/httphatch/hatch/cmd"
@@ -11,6 +12,7 @@ func main() {
 	cmd.SetAppIcon(appIcon)
 
 	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- **SSE log stream (fixes #2):** Caddy stderr now flows through the combined writer (file + LogHub) instead of only lumberjack. Replaced `zerolog.MultiLevelWriter` with `io.MultiWriter` to send all bytes unconditionally. Added a 200-entry ring buffer to LogHub so new dashboard connections receive recent history.
- **Startup errors:** `main.go` now prints errors to stderr instead of exiting silently. `hatch up` checks for port conflicts before launching the daemon and verifies the daemon is healthy afterward.
- **Shared API address:** Extracted `api.DefaultAddr` constant, replacing 4 hardcoded occurrences of `127.0.0.1:42824`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (including new LogHub tests)
- [x] Verified dashboard log viewer receives Caddy access logs in real time
- [x] Verified new SSE connections receive buffered history
- [x] Verified `hatch app` prints error when daemon is not running
- [x] Verified `hatch up` detects port conflicts and reports them clearly