### PR TITLE
Skip macOS build on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -61,6 +63,7 @@ jobs:
         working-directory: frontend
 
   build:
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
     needs: [test, lint, frontend]
     steps:


### PR DESCRIPTION
## Summary

- Build job now only runs on tag pushes (`v*`) or manual `workflow_dispatch`
- Test, lint, and frontend jobs still run on every push to main and every PR

Closes #36

## Test plan

- [x] CI on this PR should run test/lint/frontend but skip the build job