### PR TITLE
Auto-detect tunnel domains from Cloudflare API

### DIFF
--- a/docs/guide/tunnels.md
+++ b/docs/guide/tunnels.md
@@ -85,6 +85,16 @@ settings:
 
 The account ID must be a 32-character hexadecimal string. You can find it in the Cloudflare dashboard under your account overview.
 
+## Auto-Detected Tunnel Domains
+
+When a `cloudflare_token` is configured, Hatch queries the Cloudflare API for each named tunnel's ingress rules. It reads the hostnames attached to the tunnel and adds Caddy routes for each one. This means requests arriving through the tunnel with external domains (e.g. `myapp.example.com`) are routed to the correct local service automatically.
+
+Without this, the tunnel sends requests with the external domain in the Host header, but Caddy only has routes for `.test` domains, causing a "no route" error.
+
+The auto-detection runs at daemon startup and on config reload. If the API call fails, Hatch logs a warning and continues without the tunnel domains. The daemon never fails to start because of a Cloudflare API issue.
+
+Without an API token, Hatch cannot detect tunnel domains. You must either set a `cloudflare_token` or configure cloudflared to connect directly to the service upstream.
+
 ## CLI Commands
 
 ### `hatch tunnel start <project>/<service>`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -16,6 +16,7 @@ settings:
   tray_icon: true
   log_level: info
   cloudflare_token: "your-api-token"
+  cloudflare_account_id: "abcdef0123456789abcdef0123456789"
 projects:
   myapp:
     domain: myapp.test
@@ -106,7 +107,7 @@ Controls the verbosity of daemon logs in `~/.hatch/logs/hatch.log`.
 - **Type:** `string`
 - **Optional**
 
-Cloudflare API token used to resolve tunnel JWTs for named tunnels. When a named tunnel is configured, Hatch uses this token to call the Cloudflare API and fetch the tunnel-specific JWT that cloudflared needs. Can be overridden per-project. See [Tunnels](/guide/tunnels) for details.
+Cloudflare API token used to resolve tunnel JWTs for named tunnels. When a named tunnel is configured, Hatch uses this token to call the Cloudflare API and fetch the tunnel-specific JWT that cloudflared needs. Hatch also queries each tunnel's ingress rules to auto-detect external hostnames and add Caddy routes for them, so requests arriving through the tunnel are routed correctly. Can be overridden per-project. See [Tunnels](/guide/tunnels) for details.
 
 ### `settings.cloudflare_account_id`
 

--- a/internal/caddy/translate.go
+++ b/internal/caddy/translate.go
@@ -23,12 +23,13 @@ type PKIPaths struct {
 // It skips disabled projects and returns a map suitable for JSON marshaling.
 // When pki.RootCert is non-empty, a PKI app is added so Caddy uses the
 // provided CA for issuing leaf certificates. dataDir controls where Caddy
-// stores certificates and PKI data.
-func Translate(cfg config.Config, pki PKIPaths, dataDir string) map[string]any {
-	infos := collectRouteInfos(cfg)
+// stores certificates and PKI data. tunnelDomains maps "project/service"
+// keys to external hostnames resolved from Cloudflare tunnel ingress rules.
+func Translate(cfg config.Config, pki PKIPaths, dataDir string, tunnelDomains map[string][]string) map[string]any {
+	infos := collectRouteInfos(cfg, tunnelDomains)
 	httpsRoutes := buildRoutes(infos)
-	httpRedirectRoutes := buildHTTPRedirectRoutes(cfg)
-	tlsConfig := buildTLSConfig(cfg, pki.RootCert)
+	httpRedirectRoutes := buildHTTPRedirectRoutes(cfg, tunnelDomains)
+	tlsConfig := buildTLSConfig(cfg, pki.RootCert, tunnelDomains)
 
 	httpsPort := fmt.Sprintf(":%d", cfg.Settings.HTTPSPort)
 	httpPort := fmt.Sprintf(":%d", cfg.Settings.HTTPPort)
@@ -86,14 +87,16 @@ type routeInfo struct {
 }
 
 // collectRouteInfos gathers all enabled proxy services from the config.
-func collectRouteInfos(cfg config.Config) []routeInfo {
+// When tunnelDomains is non-nil, additional routeInfo entries are created
+// for each external hostname attached to a service's named tunnel.
+func collectRouteInfos(cfg config.Config, tunnelDomains map[string][]string) []routeInfo {
 	var infos []routeInfo
 
-	for _, proj := range cfg.Projects {
+	for projName, proj := range cfg.Projects {
 		if !proj.Enabled {
 			continue
 		}
-		for _, svc := range proj.Services {
+		for svcName, svc := range proj.Services {
 			if svc.Proxy == "" {
 				continue
 			}
@@ -105,6 +108,14 @@ func collectRouteInfos(cfg config.Config) []routeInfo {
 				domain:  domain,
 				service: svc,
 			})
+
+			key := projName + "/" + svcName
+			for _, td := range tunnelDomains[key] {
+				infos = append(infos, routeInfo{
+					domain:  td,
+					service: svc,
+				})
+			}
 		}
 	}
 
@@ -523,7 +534,7 @@ func buildServerErrorRoutes(infos []routeInfo) map[string]any {
 // handler with a 302 redirect. A catch-all redirect (no host matcher) is appended
 // after the domain-specific routes so that unconfigured domains also redirect to
 // HTTPS, where the on-demand TLS and fallback 404 route handle them.
-func buildHTTPRedirectRoutes(cfg config.Config) []map[string]any {
+func buildHTTPRedirectRoutes(cfg config.Config, tunnelDomains map[string][]string) []map[string]any {
 	redirectHandler := []map[string]any{
 		{
 			"handler":     "static_response",
@@ -534,7 +545,7 @@ func buildHTTPRedirectRoutes(cfg config.Config) []map[string]any {
 		},
 	}
 
-	domains := collectDomains(cfg)
+	domains := collectDomains(cfg, tunnelDomains)
 	if len(domains) == 0 {
 		return []map[string]any{
 			{
@@ -562,8 +573,8 @@ func buildHTTPRedirectRoutes(cfg config.Config) []map[string]any {
 // A catch-all on-demand policy is appended so that requests to unconfigured
 // domains still get a valid certificate during the TLS handshake, allowing
 // the HTTP fallback route to serve the 404 debug page.
-func buildTLSConfig(cfg config.Config, rootCACert string) map[string]any {
-	domains := collectDomains(cfg)
+func buildTLSConfig(cfg config.Config, rootCACert string, tunnelDomains map[string][]string) map[string]any {
+	domains := collectDomains(cfg, tunnelDomains)
 
 	issuer := map[string]any{"module": "internal"}
 	if rootCACert != "" {
@@ -618,20 +629,26 @@ func buildPKIConfig(pki PKIPaths) map[string]any {
 // collectDomains returns all unique domains across enabled projects, sorted.
 // Each service's full domain is listed explicitly so that Caddy's automatic
 // HTTPS exact-match check recognises them against the TLS automation policy.
-func collectDomains(cfg config.Config) []string {
+// Tunnel domains are included so certificates are pre-generated.
+func collectDomains(cfg config.Config, tunnelDomains map[string][]string) []string {
 	domainSet := make(map[string]bool)
 
-	for _, proj := range cfg.Projects {
+	for projName, proj := range cfg.Projects {
 		if !proj.Enabled {
 			continue
 		}
-		for _, svc := range proj.Services {
+		for svcName, svc := range proj.Services {
 			if svc.Proxy == "" {
 				continue
 			}
 			domainSet[proj.Domain] = true
 			if svc.Subdomain != "" {
 				domainSet[svc.Subdomain+"."+proj.Domain] = true
+			}
+
+			key := projName + "/" + svcName
+			for _, td := range tunnelDomains[key] {
+				domainSet[td] = true
 			}
 		}
 	}

--- a/internal/caddy/translate_test.go
+++ b/internal/caddy/translate_test.go
@@ -56,7 +56,7 @@ func TestTranslate_SingleService(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -134,7 +134,7 @@ func TestTranslate_PathRouting(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -173,7 +173,7 @@ func TestTranslate_SubdomainRouting(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -209,7 +209,7 @@ func TestTranslate_WebSocket(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -254,7 +254,7 @@ func TestTranslate_WebSocket(t *testing.T) {
 
 func TestTranslate_RouteOrdering(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -316,7 +316,7 @@ func TestTranslate_DisabledSkipped(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -353,7 +353,7 @@ func TestTranslate_MultipleProjects(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -376,7 +376,7 @@ func TestTranslate_MultipleProjects(t *testing.T) {
 
 func TestTranslate_HTTPRedirects(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpServer := servers["hatch_http"].(map[string]any)
@@ -421,7 +421,7 @@ func TestTranslate_HTTPRedirects(t *testing.T) {
 
 func TestTranslate_TLSAutomation(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	tls := result["apps"].(map[string]any)["tls"].(map[string]any)
 	automation := tls["automation"].(map[string]any)
@@ -468,7 +468,7 @@ func TestTranslate_CustomPorts(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 
@@ -493,7 +493,7 @@ func TestTranslate_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	// Should still produce valid structure.
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
@@ -545,7 +545,7 @@ func TestTranslate_PKIConfig(t *testing.T) {
 		IntermediateKey:  "/home/user/.hatch/certs/intermediateCA-key.pem",
 	}
 
-	result := Translate(cfg, pkiPaths, "/test/data/caddy")
+	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil)
 
 	apps := result["apps"].(map[string]any)
 
@@ -612,7 +612,7 @@ func TestTranslate_PKIConfig_RootOnlyNoIntermediate(t *testing.T) {
 		RootKey:  "/home/user/.hatch/certs/rootCA-key.pem",
 	}
 
-	result := Translate(cfg, pkiPaths, "/test/data/caddy")
+	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil)
 
 	apps := result["apps"].(map[string]any)
 	pki := apps["pki"].(map[string]any)
@@ -649,7 +649,7 @@ func TestTranslate_PKIConfig_NoPKIWhenEmpty(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	apps := result["apps"].(map[string]any)
 
@@ -669,7 +669,7 @@ func TestTranslate_PKIConfig_NoPKIWhenEmpty(t *testing.T) {
 
 func TestTranslate_GoldenFile(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	got, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
@@ -714,7 +714,7 @@ func TestTranslate_CommandOnlyServiceSkipped(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -760,7 +760,7 @@ func TestTranslate_AllCommandOnlyProject(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -779,7 +779,7 @@ func TestTranslate_AllCommandOnlyProject(t *testing.T) {
 
 func TestTranslate_FallbackRoute(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -837,7 +837,7 @@ func TestTranslate_FallbackRoute_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -867,7 +867,7 @@ func TestTranslate_ErrorResponse(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -927,7 +927,7 @@ func TestTranslate_ErrorResponse(t *testing.T) {
 
 func TestTranslate_ServerErrorRoutes(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -972,7 +972,7 @@ func TestTranslate_ServerErrorRoutes_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy")
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -1003,5 +1003,125 @@ func TestExtractDialAddress(t *testing.T) {
 				t.Errorf("extractDialAddress(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTranslate_TunnelDomains(t *testing.T) {
+	cfg := config.Config{
+		Version: 1,
+		Settings: config.Settings{
+			HTTPPort:  80,
+			HTTPSPort: 443,
+		},
+		Projects: map[string]config.Project{
+			"myapp": {
+				Domain:  "myapp.test",
+				Path:    "/path/to/myapp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"web": {Proxy: "http://localhost:3000", Tunnel: "my-tunnel"},
+				},
+			},
+		},
+	}
+
+	tunnelDomains := map[string][]string{
+		"myapp/web": {"myapp.example.com", "app.example.com"},
+	}
+
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", tunnelDomains)
+
+	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
+	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
+
+	// 1 .test route + 2 tunnel domain routes + 1 fallback = 4 routes.
+	if len(routes) != 4 {
+		t.Fatalf("expected 4 routes, got %d", len(routes))
+	}
+
+	// Collect all host matchers (excluding fallback which has no match).
+	var hosts []string
+	for _, route := range routes {
+		matchRaw, ok := route["match"]
+		if !ok {
+			continue
+		}
+		match := matchRaw.([]map[string]any)[0]
+		hosts = append(hosts, match["host"].([]string)...)
+	}
+
+	expected := map[string]bool{
+		"myapp.test":        false,
+		"myapp.example.com": false,
+		"app.example.com":   false,
+	}
+	for _, h := range hosts {
+		if _, ok := expected[h]; ok {
+			expected[h] = true
+		}
+	}
+	for domain, found := range expected {
+		if !found {
+			t.Errorf("expected route for domain %s, not found", domain)
+		}
+	}
+
+	// All matched routes should proxy to the same upstream.
+	for _, route := range routes {
+		if _, ok := route["match"]; !ok {
+			continue // skip fallback
+		}
+		subroute := route["handle"].([]map[string]any)[0]
+		subRoutes := subroute["routes"].([]map[string]any)
+		proxyHandler := subRoutes[1]["handle"].([]map[string]any)[1]
+		upstreams := proxyHandler["upstreams"].([]map[string]any)
+		if upstreams[0]["dial"] != "localhost:3000" {
+			t.Errorf("expected dial localhost:3000, got %s", upstreams[0]["dial"])
+		}
+	}
+
+	// TLS subjects should include tunnel domains.
+	tls := result["apps"].(map[string]any)["tls"].(map[string]any)
+	policies := tls["automation"].(map[string]any)["policies"].([]map[string]any)
+	subjects := policies[0]["subjects"].([]string)
+
+	subjectSet := make(map[string]bool)
+	for _, s := range subjects {
+		subjectSet[s] = true
+	}
+	for _, domain := range []string{"myapp.test", "myapp.example.com", "app.example.com"} {
+		if !subjectSet[domain] {
+			t.Errorf("expected TLS subject %s, not found in %v", domain, subjects)
+		}
+	}
+}
+
+func TestTranslate_TunnelDomains_NilMap(t *testing.T) {
+	cfg := config.Config{
+		Version: 1,
+		Settings: config.Settings{
+			HTTPPort:  80,
+			HTTPSPort: 443,
+		},
+		Projects: map[string]config.Project{
+			"myapp": {
+				Domain:  "myapp.test",
+				Path:    "/path/to/myapp",
+				Enabled: true,
+				Services: map[string]config.Service{
+					"web": {Proxy: "http://localhost:3000"},
+				},
+			},
+		},
+	}
+
+	// nil tunnelDomains should work the same as before.
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+
+	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
+	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
+
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes with nil tunnelDomains, got %d", len(routes))
 	}
 }

--- a/internal/cloudflare/client.go
+++ b/internal/cloudflare/client.go
@@ -145,6 +145,76 @@ func (c *Client) getTunnelToken(apiToken, accountID, tunnelID string) (string, e
 	return token, nil
 }
 
+// GetTunnelHostnames returns the hostnames configured in a named tunnel's
+// ingress rules. If accountID is empty, it auto-detects the account.
+func (c *Client) GetTunnelHostnames(apiToken, accountID, tunnelName string) ([]string, error) {
+	if apiToken == "" {
+		return nil, fmt.Errorf("cloudflare API token is required")
+	}
+	if accountID != "" && !validAccountID.MatchString(accountID) {
+		return nil, fmt.Errorf("invalid cloudflare account ID format: %q", accountID)
+	}
+
+	var err error
+	if accountID == "" {
+		accountID, err = c.getAccountID(apiToken)
+		if err != nil {
+			return nil, fmt.Errorf("looking up cloudflare account: %w", err)
+		}
+	}
+
+	tunnelID, err := c.findTunnelByName(apiToken, accountID, tunnelName)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.getTunnelHostnames(apiToken, accountID, tunnelID)
+}
+
+// maxTunnelHostnames caps the number of hostnames accepted from a single
+// tunnel's ingress rules to prevent unbounded Caddy config growth.
+const maxTunnelHostnames = 100
+
+// validHostname matches a valid FQDN (no wildcards, no IP addresses).
+var validHostname = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+
+func (c *Client) getTunnelHostnames(apiToken, accountID, tunnelID string) ([]string, error) {
+	u := fmt.Sprintf("%s/accounts/%s/cfd_tunnel/%s/configurations",
+		c.baseURL, url.PathEscape(accountID), url.PathEscape(tunnelID))
+
+	body, err := c.doGet(apiToken, u)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Config struct {
+			Ingress []struct {
+				Hostname string `json:"hostname"`
+				Service  string `json:"service"`
+			} `json:"ingress"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parsing tunnel config response: %w", err)
+	}
+
+	var hostnames []string
+	for _, rule := range result.Config.Ingress {
+		if rule.Hostname == "" {
+			continue
+		}
+		if !validHostname.MatchString(rule.Hostname) {
+			continue
+		}
+		hostnames = append(hostnames, rule.Hostname)
+		if len(hostnames) >= maxTunnelHostnames {
+			break
+		}
+	}
+	return hostnames, nil
+}
+
 func (c *Client) doGet(apiToken, rawURL string) (json.RawMessage, error) {
 	req, err := http.NewRequest("GET", rawURL, nil)
 	if err != nil {

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -132,6 +132,111 @@ func TestResolveTunnelToken_NoAccounts(t *testing.T) {
 	}
 }
 
+func TestGetTunnelHostnames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer valid-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			resp := map[string]any{"success": false, "errors": []map[string]any{{"code": 9109, "message": "Invalid access token"}}}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		switch {
+		case r.URL.Path == "/accounts":
+			jsonResponse(w, []account{{ID: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", Name: "My Account"}})
+		case strings.HasSuffix(r.URL.Path, "/cfd_tunnel") && r.URL.Query().Get("name") == "my-tunnel":
+			jsonResponse(w, []tunnel{{ID: "f1e2d3c4-b5a6-4f1e-ad3c-4b5a6f1e2d3c", Name: "my-tunnel"}})
+		case strings.HasSuffix(r.URL.Path, "/f1e2d3c4-b5a6-4f1e-ad3c-4b5a6f1e2d3c/configurations"):
+			jsonResponse(w, map[string]any{
+				"config": map[string]any{
+					"ingress": []map[string]any{
+						{"hostname": "myapp.example.com", "service": "http://localhost:3000"},
+						{"hostname": "api.example.com", "service": "http://localhost:8000"},
+						{"service": "http_status:404"},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+
+	t.Run("extracts hostnames and skips catch-all", func(t *testing.T) {
+		hostnames, err := c.GetTunnelHostnames("valid-token", "", "my-tunnel")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(hostnames) != 2 {
+			t.Fatalf("expected 2 hostnames, got %d", len(hostnames))
+		}
+		if hostnames[0] != "myapp.example.com" {
+			t.Errorf("expected myapp.example.com, got %s", hostnames[0])
+		}
+		if hostnames[1] != "api.example.com" {
+			t.Errorf("expected api.example.com, got %s", hostnames[1])
+		}
+	})
+
+	t.Run("with explicit account ID", func(t *testing.T) {
+		hostnames, err := c.GetTunnelHostnames("valid-token", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", "my-tunnel")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(hostnames) != 2 {
+			t.Fatalf("expected 2 hostnames, got %d", len(hostnames))
+		}
+	})
+
+	t.Run("empty API token", func(t *testing.T) {
+		_, err := c.GetTunnelHostnames("", "", "my-tunnel")
+		if err == nil || !strings.Contains(err.Error(), "API token is required") {
+			t.Errorf("expected 'API token is required' error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		_, err := c.GetTunnelHostnames("bad-token", "", "my-tunnel")
+		if err == nil || !strings.Contains(err.Error(), "invalid or lacks required permissions") {
+			t.Errorf("expected auth error, got: %v", err)
+		}
+	})
+}
+
+func TestGetTunnelHostnames_EmptyIngress(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/accounts":
+			jsonResponse(w, []account{{ID: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4", Name: "My Account"}})
+		case strings.HasSuffix(r.URL.Path, "/cfd_tunnel") && r.URL.Query().Get("name") == "empty-tunnel":
+			jsonResponse(w, []tunnel{{ID: "f1e2d3c4-b5a6-4f1e-ad3c-4b5a6f1e2d3c", Name: "empty-tunnel"}})
+		case strings.HasSuffix(r.URL.Path, "/configurations"):
+			jsonResponse(w, map[string]any{
+				"config": map[string]any{
+					"ingress": []map[string]any{
+						{"service": "http_status:404"},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{baseURL: srv.URL, httpClient: srv.Client()}
+	hostnames, err := c.GetTunnelHostnames("valid-token", "", "empty-tunnel")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(hostnames) != 0 {
+		t.Errorf("expected 0 hostnames for catch-all-only ingress, got %d", len(hostnames))
+	}
+}
+
 func TestResolveTunnelToken_APIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/accounts" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/httphatch/hatch/internal/api"
 	"github.com/httphatch/hatch/internal/caddy"
 	"github.com/httphatch/hatch/internal/certs"
+	"github.com/httphatch/hatch/internal/cloudflare"
 	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/dns"
 	"github.com/httphatch/hatch/internal/health"
@@ -134,13 +135,23 @@ func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShowe
 	d.caddy = caddySrv
 	log.Info().Msg("caddy server started")
 
+	// Resolve tunnel domains from Cloudflare API before building Caddy config.
+	tunnelDomains := tunnel.ResolveTunnelDomains(cfg, cloudflare.NewClient())
+	if len(tunnelDomains) > 0 {
+		total := 0
+		for _, hs := range tunnelDomains {
+			total += len(hs)
+		}
+		log.Info().Int("domains", total).Int("services", len(tunnelDomains)).Msg("resolved tunnel domains")
+	}
+
 	// Load translated config into Caddy.
 	caddyCfg := caddy.Translate(cfg, caddy.PKIPaths{
 		RootCert:         d.caPaths.Cert,
 		RootKey:          d.caPaths.Key,
 		IntermediateCert: d.caPaths.IntermediateCert,
 		IntermediateKey:  d.caPaths.IntermediateKey,
-	}, caddy.DataDir())
+	}, caddy.DataDir(), tunnelDomains)
 	if err := caddySrv.LoadConfig(ctx, caddyCfg); err != nil {
 		d.shutdownPartial()
 		return fmt.Errorf("load caddy config: %w", err)
@@ -349,12 +360,14 @@ func (d *Daemon) onConfigReload(cfg config.Config) {
 	d.cfg = cfg
 	d.mu.Unlock()
 
+	tunnelDomains := tunnel.ResolveTunnelDomains(cfg, cloudflare.NewClient())
+
 	caddyCfg := caddy.Translate(cfg, caddy.PKIPaths{
 		RootCert:         d.caPaths.Cert,
 		RootKey:          d.caPaths.Key,
 		IntermediateCert: d.caPaths.IntermediateCert,
 		IntermediateKey:  d.caPaths.IntermediateKey,
-	}, caddy.DataDir())
+	}, caddy.DataDir(), tunnelDomains)
 	if err := d.caddy.LoadConfig(context.Background(), caddyCfg); err != nil {
 		log.Error().Err(err).Msg("failed to reload caddy config")
 		return

--- a/internal/tunnel/resolve.go
+++ b/internal/tunnel/resolve.go
@@ -1,0 +1,60 @@
+package tunnel
+
+import (
+	"github.com/rs/zerolog/log"
+
+	"github.com/httphatch/hatch/internal/config"
+)
+
+// HostnameResolver fetches the hostnames attached to a named Cloudflare tunnel.
+type HostnameResolver interface {
+	GetTunnelHostnames(apiToken, accountID, tunnelName string) ([]string, error)
+}
+
+// ResolveTunnelDomains queries the Cloudflare API for each named tunnel in the
+// config and returns a map of "project/service" to the hostnames configured in
+// the tunnel's ingress rules. Failures are logged as warnings; partial results
+// are returned so the daemon is never blocked by a Cloudflare API issue.
+func ResolveTunnelDomains(cfg config.Config, resolver HostnameResolver) map[string][]string {
+	result := make(map[string][]string)
+
+	for projName, proj := range cfg.Projects {
+		if !proj.Enabled {
+			continue
+		}
+		for svcName, svc := range proj.Services {
+			tunnelVal := string(svc.Tunnel)
+			if tunnelVal == "" || tunnelVal == "true" {
+				continue
+			}
+
+			token := proj.CloudflareToken
+			if token == "" {
+				token = cfg.Settings.CloudflareToken
+			}
+			if token == "" {
+				continue
+			}
+
+			accountID := cfg.Settings.CloudflareAccountID
+
+			hostnames, err := resolver.GetTunnelHostnames(token, accountID, tunnelVal)
+			if err != nil {
+				log.Warn().
+					Err(err).
+					Str("project", projName).
+					Str("service", svcName).
+					Str("tunnel", tunnelVal).
+					Msg("failed to resolve tunnel hostnames")
+				continue
+			}
+
+			if len(hostnames) > 0 {
+				key := projName + "/" + svcName
+				result[key] = hostnames
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/tunnel/resolve_test.go
+++ b/internal/tunnel/resolve_test.go
@@ -1,0 +1,253 @@
+package tunnel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/httphatch/hatch/internal/config"
+)
+
+type mockResolver struct {
+	hostnames map[string][]string
+	err       error
+}
+
+func (m *mockResolver) GetTunnelHostnames(apiToken, accountID, tunnelName string) ([]string, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.hostnames[tunnelName], nil
+}
+
+func TestResolveTunnelDomains(t *testing.T) {
+	t.Run("resolves named tunnel with token", func(t *testing.T) {
+		cfg := config.Config{
+			Settings: config.Settings{
+				CloudflareToken: "test-token",
+			},
+			Projects: map[string]config.Project{
+				"myapp": {
+					Enabled: true,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "my-tunnel",
+						},
+					},
+				},
+			},
+		}
+
+		resolver := &mockResolver{
+			hostnames: map[string][]string{
+				"my-tunnel": {"myapp.example.com", "api.example.com"},
+			},
+		}
+
+		result := ResolveTunnelDomains(cfg, resolver)
+
+		domains, ok := result["myapp/web"]
+		if !ok {
+			t.Fatal("expected myapp/web in result")
+		}
+		if len(domains) != 2 {
+			t.Fatalf("expected 2 domains, got %d", len(domains))
+		}
+		if domains[0] != "myapp.example.com" {
+			t.Errorf("expected myapp.example.com, got %s", domains[0])
+		}
+		if domains[1] != "api.example.com" {
+			t.Errorf("expected api.example.com, got %s", domains[1])
+		}
+	})
+
+	t.Run("skips quick tunnels", func(t *testing.T) {
+		cfg := config.Config{
+			Settings: config.Settings{
+				CloudflareToken: "test-token",
+			},
+			Projects: map[string]config.Project{
+				"myapp": {
+					Enabled: true,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "true",
+						},
+					},
+				},
+			},
+		}
+
+		resolver := &mockResolver{
+			hostnames: map[string][]string{},
+		}
+
+		result := ResolveTunnelDomains(cfg, resolver)
+		if len(result) != 0 {
+			t.Errorf("expected empty result for quick tunnel, got %v", result)
+		}
+	})
+
+	t.Run("skips named tunnels without token", func(t *testing.T) {
+		cfg := config.Config{
+			Projects: map[string]config.Project{
+				"myapp": {
+					Enabled: true,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "my-tunnel",
+						},
+					},
+				},
+			},
+		}
+
+		resolver := &mockResolver{
+			hostnames: map[string][]string{
+				"my-tunnel": {"myapp.example.com"},
+			},
+		}
+
+		result := ResolveTunnelDomains(cfg, resolver)
+		if len(result) != 0 {
+			t.Errorf("expected empty result without token, got %v", result)
+		}
+	})
+
+	t.Run("skips disabled projects", func(t *testing.T) {
+		cfg := config.Config{
+			Settings: config.Settings{
+				CloudflareToken: "test-token",
+			},
+			Projects: map[string]config.Project{
+				"myapp": {
+					Enabled: false,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "my-tunnel",
+						},
+					},
+				},
+			},
+		}
+
+		resolver := &mockResolver{
+			hostnames: map[string][]string{
+				"my-tunnel": {"myapp.example.com"},
+			},
+		}
+
+		result := ResolveTunnelDomains(cfg, resolver)
+		if len(result) != 0 {
+			t.Errorf("expected empty result for disabled project, got %v", result)
+		}
+	})
+
+	t.Run("uses project-level token over global", func(t *testing.T) {
+		cfg := config.Config{
+			Settings: config.Settings{
+				CloudflareToken: "global-token",
+			},
+			Projects: map[string]config.Project{
+				"myapp": {
+					Enabled:         true,
+					CloudflareToken: "project-token",
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "my-tunnel",
+						},
+					},
+				},
+			},
+		}
+
+		var calledWithToken string
+		resolver := &mockResolver{
+			hostnames: map[string][]string{
+				"my-tunnel": {"myapp.example.com"},
+			},
+		}
+		// Override with a custom resolver to capture the token.
+		captureResolver := &tokenCapture{
+			inner:    resolver,
+			captured: &calledWithToken,
+		}
+
+		result := ResolveTunnelDomains(cfg, captureResolver)
+		if len(result) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(result))
+		}
+		if calledWithToken != "project-token" {
+			t.Errorf("expected project-token, got %s", calledWithToken)
+		}
+	})
+
+	t.Run("API error returns partial results", func(t *testing.T) {
+		cfg := config.Config{
+			Settings: config.Settings{
+				CloudflareToken: "test-token",
+			},
+			Projects: map[string]config.Project{
+				"good": {
+					Enabled: true,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:3000",
+							Tunnel: "good-tunnel",
+						},
+					},
+				},
+				"bad": {
+					Enabled: true,
+					Services: map[string]config.Service{
+						"web": {
+							Proxy:  "http://localhost:4000",
+							Tunnel: "bad-tunnel",
+						},
+					},
+				},
+			},
+		}
+
+		resolver := &selectiveResolver{
+			hostnames: map[string][]string{
+				"good-tunnel": {"good.example.com"},
+			},
+			failOn: "bad-tunnel",
+		}
+
+		result := ResolveTunnelDomains(cfg, resolver)
+		if _, ok := result["good/web"]; !ok {
+			t.Error("expected good/web in partial result")
+		}
+		if _, ok := result["bad/web"]; ok {
+			t.Error("expected bad/web to be absent from partial result")
+		}
+	})
+}
+
+type tokenCapture struct {
+	inner    HostnameResolver
+	captured *string
+}
+
+func (tc *tokenCapture) GetTunnelHostnames(apiToken, accountID, tunnelName string) ([]string, error) {
+	*tc.captured = apiToken
+	return tc.inner.GetTunnelHostnames(apiToken, accountID, tunnelName)
+}
+
+type selectiveResolver struct {
+	hostnames map[string][]string
+	failOn    string
+}
+
+func (s *selectiveResolver) GetTunnelHostnames(apiToken, accountID, tunnelName string) ([]string, error) {
+	if tunnelName == s.failOn {
+		return nil, fmt.Errorf("API error for tunnel %s", tunnelName)
+	}
+	return s.hostnames[tunnelName], nil
+}


### PR DESCRIPTION
Closes #45

## Summary

- Query each named tunnel's Cloudflare ingress rules at daemon startup and config reload to discover external hostnames
- Add Caddy routes and TLS subjects for those hostnames so requests arriving through the tunnel are routed correctly
- Validate hostnames from the API (FQDN format, capped at 100 per tunnel) before injecting into Caddy config
- Log warnings and continue with partial results when API calls fail; the daemon never fails to start over a Cloudflare API issue

## Files changed

- `internal/cloudflare/client.go` — `GetTunnelHostnames`, `getTunnelHostnames` methods with hostname validation
- `internal/tunnel/resolve.go` — `ResolveTunnelDomains` function with `HostnameResolver` interface
- `internal/caddy/translate.go` — `Translate`, `collectRouteInfos`, `collectDomains` accept tunnel domains
- `internal/daemon/daemon.go` — resolve tunnel domains before Caddy config (startup + reload)
- `docs/guide/tunnels.md` — document auto-detection behavior
- `docs/reference/config.md` — update `cloudflare_token` description, add `cloudflare_account_id` to example

## Test plan

- [ ] `go test ./internal/cloudflare/...` — hostname extraction tests pass
- [ ] `go test ./internal/tunnel/...` — resolver tests cover named tunnels with token, quick tunnels (skipped), no token (skipped), disabled projects, API errors (partial results)
- [ ] `go test ./internal/caddy/...` — tunnel domain routing + TLS subject tests pass
- [ ] `go vet ./...` — no issues