### PR TITLE
Route named tunnel traffic through rewrite proxies

### DIFF
--- a/internal/caddy/translate.go
+++ b/internal/caddy/translate.go
@@ -25,8 +25,8 @@ type PKIPaths struct {
 // provided CA for issuing leaf certificates. dataDir controls where Caddy
 // stores certificates and PKI data. tunnelDomains maps "project/service"
 // keys to external hostnames resolved from Cloudflare tunnel ingress rules.
-func Translate(cfg config.Config, pki PKIPaths, dataDir string, tunnelDomains map[string][]string) map[string]any {
-	infos := collectRouteInfos(cfg, tunnelDomains)
+func Translate(cfg config.Config, pki PKIPaths, dataDir string, tunnelDomains map[string][]string, tunnelProxies map[string]string) map[string]any {
+	infos := collectRouteInfos(cfg, tunnelDomains, tunnelProxies)
 	httpsRoutes := buildRoutes(infos)
 	httpRedirectRoutes := buildHTTPRedirectRoutes(cfg, tunnelDomains)
 	tlsConfig := buildTLSConfig(cfg, pki.RootCert, tunnelDomains)
@@ -82,14 +82,17 @@ func Translate(cfg config.Config, pki PKIPaths, dataDir string, tunnelDomains ma
 
 // routeInfo holds metadata for sorting routes by specificity.
 type routeInfo struct {
-	domain  string
-	service config.Service
+	domain        string
+	service       config.Service
+	proxyOverride string // rewrite proxy address for tunnel domain routes
 }
 
 // collectRouteInfos gathers all enabled proxy services from the config.
 // When tunnelDomains is non-nil, additional routeInfo entries are created
 // for each external hostname attached to a service's named tunnel.
-func collectRouteInfos(cfg config.Config, tunnelDomains map[string][]string) []routeInfo {
+// When tunnelProxies is non-nil, tunnel domain routes use the rewrite proxy
+// address instead of the original upstream.
+func collectRouteInfos(cfg config.Config, tunnelDomains map[string][]string, tunnelProxies map[string]string) []routeInfo {
 	var infos []routeInfo
 
 	for projName, proj := range cfg.Projects {
@@ -110,10 +113,12 @@ func collectRouteInfos(cfg config.Config, tunnelDomains map[string][]string) []r
 			})
 
 			key := projName + "/" + svcName
+			proxyAddr := tunnelProxies[key]
 			for _, td := range tunnelDomains[key] {
 				infos = append(infos, routeInfo{
-					domain:  td,
-					service: svc,
+					domain:        td,
+					service:       svc,
+					proxyOverride: proxyAddr,
 				})
 			}
 		}
@@ -147,7 +152,11 @@ func buildRoutes(infos []routeInfo) []map[string]any {
 
 	routes := make([]map[string]any, 0, len(sorted)+1)
 	for _, info := range sorted {
-		routes = append(routes, buildRoute(info.domain, info.service))
+		proxyURL := info.service.Proxy
+		if info.proxyOverride != "" {
+			proxyURL = info.proxyOverride
+		}
+		routes = append(routes, buildRoute(info.domain, info.service, proxyURL))
 	}
 
 	if len(routes) > 0 {
@@ -184,7 +193,9 @@ func corsHeaders() map[string][]string {
 
 // buildRoute builds a single HTTPS route with host matcher, optional path matcher,
 // and a subroute that handles CORS preflight and adds CORS headers to responses.
-func buildRoute(domain string, svc config.Service) map[string]any {
+// proxyURL is the upstream address to proxy to (may differ from svc.Proxy when
+// a rewrite proxy is in use for tunnel domain routes).
+func buildRoute(domain string, svc config.Service, proxyURL string) map[string]any {
 	match := map[string]any{
 		"host": []string{domain},
 	}
@@ -192,7 +203,7 @@ func buildRoute(domain string, svc config.Service) map[string]any {
 		match["path"] = []string{svc.Route}
 	}
 
-	proxyHandler := buildReverseProxyHandler(svc.Proxy, svc.WebSocket, domain)
+	proxyHandler := buildReverseProxyHandler(proxyURL, svc.WebSocket, domain, svc.Proxy)
 
 	cors := corsHeaders()
 
@@ -242,11 +253,13 @@ func buildRoute(domain string, svc config.Service) map[string]any {
 // buildReverseProxyHandler builds a reverse_proxy handler with the dial address
 // extracted from proxyURL. If websocket is true, it adds flush_interval: -1 and
 // Connection/Upgrade header forwarding. The domain is used for error response pages.
-func buildReverseProxyHandler(proxyURL string, websocket bool, domain string) map[string]any {
+// displayUpstream is shown on error pages and may differ from proxyURL when a
+// rewrite proxy sits between Caddy and the real upstream.
+func buildReverseProxyHandler(proxyURL string, websocket bool, domain, displayUpstream string) map[string]any {
 	handler := map[string]any{
 		"handler":          "reverse_proxy",
 		"upstreams":        []map[string]any{{"dial": extractDialAddress(proxyURL)}},
-		"handle_response":  buildErrorResponse(domain, proxyURL),
+		"handle_response":  buildErrorResponse(domain, displayUpstream),
 	}
 
 	if websocket {

--- a/internal/caddy/translate_test.go
+++ b/internal/caddy/translate_test.go
@@ -56,7 +56,7 @@ func TestTranslate_SingleService(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -134,7 +134,7 @@ func TestTranslate_PathRouting(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -173,7 +173,7 @@ func TestTranslate_SubdomainRouting(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -209,7 +209,7 @@ func TestTranslate_WebSocket(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -254,7 +254,7 @@ func TestTranslate_WebSocket(t *testing.T) {
 
 func TestTranslate_RouteOrdering(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -316,7 +316,7 @@ func TestTranslate_DisabledSkipped(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -353,7 +353,7 @@ func TestTranslate_MultipleProjects(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -376,7 +376,7 @@ func TestTranslate_MultipleProjects(t *testing.T) {
 
 func TestTranslate_HTTPRedirects(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpServer := servers["hatch_http"].(map[string]any)
@@ -421,7 +421,7 @@ func TestTranslate_HTTPRedirects(t *testing.T) {
 
 func TestTranslate_TLSAutomation(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	tls := result["apps"].(map[string]any)["tls"].(map[string]any)
 	automation := tls["automation"].(map[string]any)
@@ -468,7 +468,7 @@ func TestTranslate_CustomPorts(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 
@@ -493,7 +493,7 @@ func TestTranslate_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	// Should still produce valid structure.
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
@@ -545,7 +545,7 @@ func TestTranslate_PKIConfig(t *testing.T) {
 		IntermediateKey:  "/home/user/.hatch/certs/intermediateCA-key.pem",
 	}
 
-	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil)
+	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil, nil)
 
 	apps := result["apps"].(map[string]any)
 
@@ -612,7 +612,7 @@ func TestTranslate_PKIConfig_RootOnlyNoIntermediate(t *testing.T) {
 		RootKey:  "/home/user/.hatch/certs/rootCA-key.pem",
 	}
 
-	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil)
+	result := Translate(cfg, pkiPaths, "/test/data/caddy", nil, nil)
 
 	apps := result["apps"].(map[string]any)
 	pki := apps["pki"].(map[string]any)
@@ -649,7 +649,7 @@ func TestTranslate_PKIConfig_NoPKIWhenEmpty(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	apps := result["apps"].(map[string]any)
 
@@ -669,7 +669,7 @@ func TestTranslate_PKIConfig_NoPKIWhenEmpty(t *testing.T) {
 
 func TestTranslate_GoldenFile(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	got, err := json.MarshalIndent(result, "", "  ")
 	if err != nil {
@@ -714,7 +714,7 @@ func TestTranslate_CommandOnlyServiceSkipped(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -760,7 +760,7 @@ func TestTranslate_AllCommandOnlyProject(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -779,7 +779,7 @@ func TestTranslate_AllCommandOnlyProject(t *testing.T) {
 
 func TestTranslate_FallbackRoute(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -837,7 +837,7 @@ func TestTranslate_FallbackRoute_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -867,7 +867,7 @@ func TestTranslate_ErrorResponse(t *testing.T) {
 		},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -927,7 +927,7 @@ func TestTranslate_ErrorResponse(t *testing.T) {
 
 func TestTranslate_ServerErrorRoutes(t *testing.T) {
 	cfg := fullConfig()
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -972,7 +972,7 @@ func TestTranslate_ServerErrorRoutes_EmptyConfig(t *testing.T) {
 		Projects: map[string]config.Project{},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	httpsServer := servers["hatch_https"].(map[string]any)
@@ -1029,7 +1029,11 @@ func TestTranslate_TunnelDomains(t *testing.T) {
 		"myapp/web": {"myapp.example.com", "app.example.com"},
 	}
 
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", tunnelDomains)
+	tunnelProxies := map[string]string{
+		"myapp/web": "http://127.0.0.1:9999",
+	}
+
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", tunnelDomains, tunnelProxies)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)
@@ -1039,44 +1043,36 @@ func TestTranslate_TunnelDomains(t *testing.T) {
 		t.Fatalf("expected 4 routes, got %d", len(routes))
 	}
 
-	// Collect all host matchers (excluding fallback which has no match).
-	var hosts []string
+	// Collect all host matchers and their dial addresses (excluding fallback).
+	hostDial := make(map[string]string)
 	for _, route := range routes {
 		matchRaw, ok := route["match"]
 		if !ok {
 			continue
 		}
 		match := matchRaw.([]map[string]any)[0]
-		hosts = append(hosts, match["host"].([]string)...)
-	}
-
-	expected := map[string]bool{
-		"myapp.test":        false,
-		"myapp.example.com": false,
-		"app.example.com":   false,
-	}
-	for _, h := range hosts {
-		if _, ok := expected[h]; ok {
-			expected[h] = true
-		}
-	}
-	for domain, found := range expected {
-		if !found {
-			t.Errorf("expected route for domain %s, not found", domain)
-		}
-	}
-
-	// All matched routes should proxy to the same upstream.
-	for _, route := range routes {
-		if _, ok := route["match"]; !ok {
-			continue // skip fallback
-		}
+		host := match["host"].([]string)[0]
 		subroute := route["handle"].([]map[string]any)[0]
 		subRoutes := subroute["routes"].([]map[string]any)
 		proxyHandler := subRoutes[1]["handle"].([]map[string]any)[1]
 		upstreams := proxyHandler["upstreams"].([]map[string]any)
-		if upstreams[0]["dial"] != "localhost:3000" {
-			t.Errorf("expected dial localhost:3000, got %s", upstreams[0]["dial"])
+		hostDial[host] = upstreams[0]["dial"].(string)
+	}
+
+	// .test route should go directly to the upstream.
+	if hostDial["myapp.test"] != "localhost:3000" {
+		t.Errorf("expected .test route dial localhost:3000, got %s", hostDial["myapp.test"])
+	}
+
+	// Tunnel domain routes should go through the rewrite proxy.
+	for _, td := range []string{"myapp.example.com", "app.example.com"} {
+		dial, ok := hostDial[td]
+		if !ok {
+			t.Errorf("expected route for domain %s, not found", td)
+			continue
+		}
+		if dial != "127.0.0.1:9999" {
+			t.Errorf("expected tunnel domain %s dial 127.0.0.1:9999, got %s", td, dial)
 		}
 	}
 
@@ -1116,7 +1112,7 @@ func TestTranslate_TunnelDomains_NilMap(t *testing.T) {
 	}
 
 	// nil tunnelDomains should work the same as before.
-	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil)
+	result := Translate(cfg, PKIPaths{}, "/test/data/caddy", nil, nil)
 
 	servers := result["apps"].(map[string]any)["http"].(map[string]any)["servers"].(map[string]any)
 	routes := servers["hatch_https"].(map[string]any)["routes"].([]map[string]any)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,22 +27,23 @@ import (
 
 // Daemon orchestrates all Hatch subsystems as a long-running background process.
 type Daemon struct {
-	caddy     *caddy.Server
-	dns       *dns.Server
-	health    *health.Checker
-	processes *process.Manager
-	tunnels   *tunnel.Manager
-	watcher   *config.Watcher
-	api       *api.Server
-	pidFile   *os.File
-	caPaths   certs.CAPaths
-	cfg       config.Config
-	mu        sync.Mutex
-	running   bool
-	version   string
-	startTime time.Time
-	logHub    *api.LogHub
-	outputHub *api.ProcessOutputHub
+	caddy          *caddy.Server
+	dns            *dns.Server
+	health         *health.Checker
+	processes      *process.Manager
+	tunnels        *tunnel.Manager
+	watcher        *config.Watcher
+	api            *api.Server
+	pidFile        *os.File
+	caPaths        certs.CAPaths
+	cfg            config.Config
+	rewriteProxies map[string]*tunnel.RewriteProxy
+	mu             sync.Mutex
+	running        bool
+	version        string
+	startTime      time.Time
+	logHub         *api.LogHub
+	outputHub      *api.ProcessOutputHub
 }
 
 // New creates a new Daemon instance with the given version and log hub.
@@ -145,13 +147,17 @@ func (d *Daemon) RunSubsystems(ctx context.Context, dashboard api.DashboardShowe
 		log.Info().Int("domains", total).Int("services", len(tunnelDomains)).Msg("resolved tunnel domains")
 	}
 
+	// Start rewrite proxies for services with tunnel domains so that
+	// named tunnel traffic through Caddy gets localhost URLs rewritten.
+	tunnelProxies := d.startTunnelProxies(cfg, tunnelDomains)
+
 	// Load translated config into Caddy.
 	caddyCfg := caddy.Translate(cfg, caddy.PKIPaths{
 		RootCert:         d.caPaths.Cert,
 		RootKey:          d.caPaths.Key,
 		IntermediateCert: d.caPaths.IntermediateCert,
 		IntermediateKey:  d.caPaths.IntermediateKey,
-	}, caddy.DataDir(), tunnelDomains)
+	}, caddy.DataDir(), tunnelDomains, tunnelProxies)
 	if err := caddySrv.LoadConfig(ctx, caddyCfg); err != nil {
 		d.shutdownPartial()
 		return fmt.Errorf("load caddy config: %w", err)
@@ -293,6 +299,9 @@ func (d *Daemon) Shutdown() error {
 		log.Info().Msg("config watcher stopped")
 	}
 
+	// Rewrite proxies (before tunnel manager).
+	d.stopTunnelProxies()
+
 	// Tunnel manager (before process manager so tunnels disconnect first).
 	if d.tunnels != nil {
 		if err := d.tunnels.StopAll(); err != nil {
@@ -362,15 +371,33 @@ func (d *Daemon) onConfigReload(cfg config.Config) {
 
 	tunnelDomains := tunnel.ResolveTunnelDomains(cfg, cloudflare.NewClient())
 
+	// Start new proxies before stopping old ones so Caddy always has a
+	// valid upstream to route to. Old proxies are stopped after Caddy
+	// switches to the new config.
+	oldProxies := d.swapTunnelProxies(cfg, tunnelDomains)
+
+	d.mu.Lock()
+	tunnelProxies := make(map[string]string, len(d.rewriteProxies))
+	for k, p := range d.rewriteProxies {
+		tunnelProxies[k] = p.Addr()
+	}
+	d.mu.Unlock()
+
 	caddyCfg := caddy.Translate(cfg, caddy.PKIPaths{
 		RootCert:         d.caPaths.Cert,
 		RootKey:          d.caPaths.Key,
 		IntermediateCert: d.caPaths.IntermediateCert,
 		IntermediateKey:  d.caPaths.IntermediateKey,
-	}, caddy.DataDir(), tunnelDomains)
+	}, caddy.DataDir(), tunnelDomains, tunnelProxies)
 	if err := d.caddy.LoadConfig(context.Background(), caddyCfg); err != nil {
 		log.Error().Err(err).Msg("failed to reload caddy config")
 		return
+	}
+
+	// Stop old proxies now that Caddy has switched to the new ones.
+	for key, proxy := range oldProxies {
+		proxy.Close()
+		log.Info().Str("service", key).Msg("old rewrite proxy stopped")
 	}
 
 	d.health.UpdateConfig(cfg)
@@ -407,6 +434,7 @@ func (d *Daemon) shutdownPartial() {
 		_ = d.api.Shutdown(ctx)
 		cancel()
 	}
+	d.stopTunnelProxies()
 	if d.tunnels != nil {
 		_ = d.tunnels.StopAll()
 	}
@@ -425,4 +453,78 @@ func (d *Daemon) shutdownPartial() {
 	if d.pidFile != nil {
 		_ = RemovePID(d.pidFile)
 	}
+}
+
+// startTunnelProxies starts rewrite proxies for services that have tunnel
+// domains. Returns a map of "project/service" keys to proxy addresses.
+func (d *Daemon) startTunnelProxies(cfg config.Config, tunnelDomains map[string][]string) map[string]string {
+	if len(tunnelDomains) == 0 {
+		return nil
+	}
+
+	newProxies := make(map[string]*tunnel.RewriteProxy, len(tunnelDomains))
+	addrs := make(map[string]string, len(tunnelDomains))
+
+	for key := range tunnelDomains {
+		upstream := upstreamForKey(cfg, key)
+		if upstream == "" {
+			continue
+		}
+		proxy, err := tunnel.StartRewriteProxy(upstream)
+		if err != nil {
+			log.Warn().Err(err).Str("service", key).Msg("failed to start rewrite proxy")
+			continue
+		}
+		newProxies[key] = proxy
+		addrs[key] = proxy.Addr()
+		log.Info().Str("service", key).Str("addr", proxy.Addr()).Msg("rewrite proxy started")
+	}
+
+	d.mu.Lock()
+	d.rewriteProxies = newProxies
+	d.mu.Unlock()
+
+	return addrs
+}
+
+// swapTunnelProxies starts new rewrite proxies and returns the old ones for
+// the caller to close after Caddy has switched to the new config.
+func (d *Daemon) swapTunnelProxies(cfg config.Config, tunnelDomains map[string][]string) map[string]*tunnel.RewriteProxy {
+	d.mu.Lock()
+	old := d.rewriteProxies
+	d.rewriteProxies = nil
+	d.mu.Unlock()
+
+	d.startTunnelProxies(cfg, tunnelDomains)
+	return old
+}
+
+// stopTunnelProxies shuts down all running rewrite proxies.
+func (d *Daemon) stopTunnelProxies() {
+	d.mu.Lock()
+	proxies := d.rewriteProxies
+	d.rewriteProxies = nil
+	d.mu.Unlock()
+
+	for key, proxy := range proxies {
+		proxy.Close()
+		log.Info().Str("service", key).Msg("rewrite proxy stopped")
+	}
+}
+
+// upstreamForKey returns the proxy URL for a "project/service" key.
+func upstreamForKey(cfg config.Config, key string) string {
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	proj, ok := cfg.Projects[parts[0]]
+	if !ok {
+		return ""
+	}
+	svc, ok := proj.Services[parts[1]]
+	if !ok {
+		return ""
+	}
+	return svc.Proxy
 }

--- a/internal/tunnel/rewrite_proxy.go
+++ b/internal/tunnel/rewrite_proxy.go
@@ -27,23 +27,23 @@ var localhostRe = regexp.MustCompile(
 	`(?:https?|wss?)://(?:localhost|127\.0\.0\.1|\[::1\]):\d+`,
 )
 
-// rewriteProxy sits between cloudflared and the upstream app server.
+// RewriteProxy sits between cloudflared and the upstream app server.
 // It does two things:
 //  1. Rewrites absolute localhost URLs in HTML responses to relative paths,
 //     preventing PNA (Private Network Access) browser blocks.
 //  2. Falls back to a discovered dev server (e.g. Vite) for asset requests
 //     that 404 on the upstream. The dev server address is extracted from
 //     localhost URLs found in the first HTML response.
-type rewriteProxy struct {
+type RewriteProxy struct {
 	server   *http.Server
 	listener net.Listener
 	addr     string
 }
 
-// startRewriteProxy starts a local HTTP proxy that forwards requests to
+// StartRewriteProxy starts a local HTTP proxy that forwards requests to
 // upstream, rewrites HTML responses, and falls back to a discovered dev
 // server for 404'd assets. Returns the proxy's listen address for cloudflared.
-func startRewriteProxy(upstream string) (*rewriteProxy, error) {
+func StartRewriteProxy(upstream string) (*RewriteProxy, error) {
 	target, err := url.Parse(upstream)
 	if err != nil {
 		return nil, fmt.Errorf("parsing upstream URL: %w", err)
@@ -99,14 +99,19 @@ func startRewriteProxy(upstream string) (*rewriteProxy, error) {
 	}
 
 	addr := fmt.Sprintf("http://127.0.0.1:%d", tcpAddr.Port)
-	return &rewriteProxy{
+	return &RewriteProxy{
 		server:   srv,
 		listener: listener,
 		addr:     addr,
 	}, nil
 }
 
-func (p *rewriteProxy) Close() {
+// Addr returns the proxy's listen address (e.g. "http://127.0.0.1:12345").
+func (p *RewriteProxy) Addr() string {
+	return p.addr
+}
+
+func (p *RewriteProxy) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = p.server.Shutdown(ctx)

--- a/internal/tunnel/rewrite_proxy_test.go
+++ b/internal/tunnel/rewrite_proxy_test.go
@@ -40,7 +40,7 @@ func TestRewriteProxy(t *testing.T) {
 	}))
 	defer appServer.Close()
 
-	proxy, err := startRewriteProxy(appServer.URL)
+	proxy, err := StartRewriteProxy(appServer.URL)
 	if err != nil {
 		t.Fatalf("starting proxy: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestRewriteProxy(t *testing.T) {
 
 	// First request: HTML page. URLs should be rewritten to relative paths
 	// and the dev server should be discovered.
-	resp, err := http.Get(proxy.addr + "/")
+	resp, err := http.Get(proxy.Addr() + "/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestRewriteProxy(t *testing.T) {
 
 	// Second request: asset that 404s on app server. Should fall back to
 	// the discovered Vite dev server.
-	resp, err = http.Get(proxy.addr + "/@vite/client")
+	resp, err = http.Get(proxy.Addr() + "/@vite/client")
 	if err != nil {
 		t.Fatalf("GET /@vite/client: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestRewriteProxy(t *testing.T) {
 	}
 
 	// Third request: another asset path.
-	resp, err = http.Get(proxy.addr + "/resources/js/app.tsx")
+	resp, err = http.Get(proxy.Addr() + "/resources/js/app.tsx")
 	if err != nil {
 		t.Fatalf("GET /resources/js/app.tsx: %v", err)
 	}
@@ -131,14 +131,14 @@ func TestRewriteProxyWebSocketFallback(t *testing.T) {
 	}))
 	defer appServer.Close()
 
-	proxy, err := startRewriteProxy(appServer.URL)
+	proxy, err := StartRewriteProxy(appServer.URL)
 	if err != nil {
 		t.Fatalf("starting proxy: %v", err)
 	}
 	defer proxy.Close()
 
 	// Load HTML to discover the dev server.
-	resp, err := http.Get(proxy.addr + "/")
+	resp, err := http.Get(proxy.Addr() + "/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestRewriteProxyWebSocketFallback(t *testing.T) {
 
 	// Simulate a WebSocket upgrade request. The upstream returns 200 (not 101),
 	// so the fallback should retry against the Vite dev server.
-	req, _ := http.NewRequest("GET", proxy.addr+"/?token=abc", nil)
+	req, _ := http.NewRequest("GET", proxy.Addr()+"/?token=abc", nil)
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "websocket")
 
@@ -174,13 +174,13 @@ func TestRewriteProxyNonHTML(t *testing.T) {
 	u, _ := url.Parse(upstream.URL)
 	port = u.Port()
 
-	proxy, err := startRewriteProxy(upstream.URL)
+	proxy, err := StartRewriteProxy(upstream.URL)
 	if err != nil {
 		t.Fatalf("starting proxy: %v", err)
 	}
 	defer proxy.Close()
 
-	resp, err := http.Get(proxy.addr + "/test.js")
+	resp, err := http.Get(proxy.Addr() + "/test.js")
 	if err != nil {
 		t.Fatalf("GET proxy: %v", err)
 	}
@@ -217,21 +217,21 @@ func TestRewriteProxySamePort(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	proxy, err := startRewriteProxy(upstream.URL)
+	proxy, err := StartRewriteProxy(upstream.URL)
 	if err != nil {
 		t.Fatalf("starting proxy: %v", err)
 	}
 	defer proxy.Close()
 
 	// Load HTML to trigger rewriting.
-	resp, err := http.Get(proxy.addr + "/")
+	resp, err := http.Get(proxy.Addr() + "/")
 	if err != nil {
 		t.Fatalf("GET /: %v", err)
 	}
 	_ = resp.Body.Close()
 
 	// Asset request should succeed directly from upstream (no fallback needed).
-	resp, err = http.Get(proxy.addr + "/@vite/client")
+	resp, err = http.Get(proxy.Addr() + "/@vite/client")
 	if err != nil {
 		t.Fatalf("GET /@vite/client: %v", err)
 	}

--- a/internal/tunnel/runner.go
+++ b/internal/tunnel/runner.go
@@ -41,7 +41,7 @@ func (cfg RunnerConfig) IsQuick() bool {
 type Runner struct {
 	cfg   RunnerConfig
 	cmd   *exec.Cmd
-	proxy *rewriteProxy
+	proxy *RewriteProxy
 	done  chan struct{}
 	err   error
 	url   string
@@ -57,7 +57,7 @@ func (r *Runner) Start() error {
 	// URLs from HTML responses. This prevents PNA (Private Network Access)
 	// errors when frameworks like Vite inject absolute localhost script tags.
 	if r.cfg.IsQuick() {
-		proxy, err := startRewriteProxy(r.cfg.Upstream)
+		proxy, err := StartRewriteProxy(r.cfg.Upstream)
 		if err != nil {
 			r.mu.Unlock()
 			return fmt.Errorf("starting rewrite proxy: %w", err)
@@ -67,7 +67,7 @@ func (r *Runner) Start() error {
 
 	cfUpstream := r.cfg.Upstream
 	if r.proxy != nil {
-		cfUpstream = r.proxy.addr
+		cfUpstream = r.proxy.Addr()
 	}
 
 	var cmd *exec.Cmd


### PR DESCRIPTION
## Summary

- Named tunnel routes through Caddy now go through a rewrite proxy that strips absolute localhost URLs from HTML responses, preventing PNA/CORS errors when frameworks like Vite inject localhost script tags
- Quick tunnels are unchanged; .test domain routes still go direct to the upstream
- Rewrite proxy lifecycle is managed by the daemon with proper mutex guarding and graceful swap during config reloads

## Traffic flow after fix

```
Quick tunnel (unchanged):
  cloudflared → rewrite proxy → upstream

Named tunnel through Caddy (new):
  cloudflared → Caddy → rewrite proxy → upstream
                        (tunnel domain routes only; .test routes still go direct)
```

## Test plan

- [x] `go test ./internal/tunnel/...` passes with exported names
- [x] `go test ./internal/caddy/...` verifies tunnel domain routes use proxy address while .test routes go direct
- [x] `go test ./...` full suite passes
- [x] `go vet ./...` clean

Closes #46