### PR TITLE
Add stop and restart controls to macOS tray menu

### DIFF
--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -66,6 +66,17 @@ The log viewer streams daemon logs in real time via server-sent events. When you
 
 Toggle the log panel with the button in the header.
 
+### Tray Icon Menu
+
+The tray icon in the macOS menu bar provides quick access to all running projects and daemon controls.
+
+- **Open Dashboard** — shows the dashboard window
+- **Add Project...** — opens the dashboard to the add project dialog
+- **Restart Hatch** — unloads and reloads the launchd plist; the daemon relaunches automatically
+- **Stop Hatch** — removes the launchd plist and stops the daemon; it will not restart on boot until you run `hatch up` again
+
+Each project appears as a submenu with its domain, an enable/disable toggle, and per-service health indicators.
+
 ### Settings
 
 The settings dialog has three tabs:

--- a/internal/daemon/control_darwin.go
+++ b/internal/daemon/control_darwin.go
@@ -1,0 +1,52 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/rs/zerolog/log"
+)
+
+// StopDaemon removes the launchd plist (to prevent KeepAlive restart)
+// then unloads the job, which sends SIGTERM to the current process.
+func (d *Daemon) StopDaemon() {
+	go func() {
+		if err := UninstallPlist(); err != nil {
+			log.Warn().Err(err).Msg("stop: uninstall plist failed")
+			return
+		}
+		if err := UnloadPlist(); err != nil {
+			log.Warn().Err(err).Msg("stop: unload plist failed")
+		}
+	}()
+}
+
+// RestartDaemon spawns a detached shell that unloads and reloads the
+// launchd plist. The shell runs in its own process group so it survives
+// the SIGTERM sent to this process during unload.
+func (d *Daemon) RestartDaemon() {
+	go func() {
+		path, err := PlistPath()
+		if err != nil {
+			log.Warn().Err(err).Msg("restart: plist path")
+			return
+		}
+		if _, err := os.Stat(path); err != nil {
+			log.Warn().Err(err).Msg("restart: plist not found")
+			return
+		}
+		// Pass the plist path via environment variable to avoid shell injection.
+		// The shell is required because unload kills this process; load must
+		// run in a detached process that survives the SIGTERM.
+		cmd := exec.Command("sh", "-c",
+			`launchctl unload "$PLIST_PATH" && launchctl load "$PLIST_PATH"`)
+		cmd.Env = append(os.Environ(), "PLIST_PATH="+path)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		if err := cmd.Start(); err != nil {
+			log.Warn().Err(err).Msg("restart: spawn failed")
+		}
+	}()
+}

--- a/internal/tray/manager.go
+++ b/internal/tray/manager.go
@@ -26,6 +26,8 @@ import (
 type DaemonControl interface {
 	ReloadConfig() error
 	HealthChecker() *health.Checker
+	StopDaemon()
+	RestartDaemon()
 }
 
 // ManagerConfig holds the dependencies for a Manager.
@@ -194,9 +196,18 @@ func (m *Manager) populateMenu() {
 
 	m.menu.AddSeparator()
 
-	// Quit Hatch (triggers full daemon + tray shutdown).
-	m.menu.Add("Quit Hatch").OnClick(func(_ *application.Context) {
-		m.app.Quit()
+	// Restart Hatch (kill + relaunch via launchd).
+	m.menu.Add("Restart Hatch").OnClick(func(_ *application.Context) {
+		if m.daemon != nil {
+			m.daemon.RestartDaemon()
+		}
+	})
+
+	// Stop Hatch (remove plist + unload via launchd).
+	m.menu.Add("Stop Hatch").OnClick(func(_ *application.Context) {
+		if m.daemon != nil {
+			m.daemon.StopDaemon()
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- Replace "Quit Hatch" tray menu item with "Restart Hatch" and "Stop Hatch"
- Stop removes the launchd plist (prevents KeepAlive restart) then unloads the job via launchctl
- Restart spawns a detached shell (own process group) that unloads and reloads the plist, surviving the daemon's SIGTERM
- Extend `DaemonControl` interface with `StopDaemon()` and `RestartDaemon()` methods
- Document the tray menu items in the dashboard guide

Closes #44

## Test plan

- [ ] `go build ./...` compiles
- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean
- [ ] Run `hatch up`, click "Stop Hatch" in tray — daemon stops, tray disappears, `hatch status` shows not running
- [ ] Run `hatch up`, click "Restart Hatch" in tray — daemon restarts, tray reappears after brief pause