### PR TITLE
Add port conflict diagnostics to hatch status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -84,6 +85,10 @@ func runStatus() error {
 		}
 	}()
 
+	// Port check cache and conflict collector.
+	portCache := make(map[int]*daemon.PortInfo)
+	var conflicts []portConflict
+
 	// Daemon state
 	running, pid, _ := daemon.IsRunning()
 	if running {
@@ -95,6 +100,17 @@ func runStatus() error {
 	} else {
 		fmt.Printf("Daemon: %s\n", red("not running"))
 		fmt.Printf("  %s Run 'hatch up' to start the daemon\n", yellow("→"))
+		for _, dp := range []int{cfg.Settings.HTTPPort, cfg.Settings.HTTPSPort} {
+			_, c := diagnosePort(dp, portCache)
+			if c != nil {
+				if c.pid > 0 {
+					fmt.Printf("  %s Port %d in use by %s (PID %d)\n", red("!"), c.port, c.process, c.pid)
+				} else {
+					fmt.Printf("  %s Port %d in use by %s\n", red("!"), c.port, c.process)
+				}
+				conflicts = append(conflicts, *c)
+			}
+		}
 	}
 
 	if len(cfg.Projects) == 0 {
@@ -153,7 +169,16 @@ func runStatus() error {
 			if upstream != "" && dialHealth(upstream) {
 				status = green("✓") + " healthy"
 			} else {
-				status = red("✗") + " unhealthy"
+				suffix := ""
+				if upstream != "" {
+					port := extractPort(upstream)
+					var c *portConflict
+					suffix, c = diagnosePort(port, portCache)
+					if c != nil {
+						conflicts = append(conflicts, *c)
+					}
+				}
+				status = red("✗") + " unhealthy" + suffix
 			}
 
 			tunnelURL := ""
@@ -206,6 +231,27 @@ func runStatus() error {
 		}
 	}
 
+	// Deduplicate and print conflict summary.
+	if len(conflicts) > 0 {
+		seen := make(map[int]bool)
+		var unique []portConflict
+		for _, c := range conflicts {
+			if !seen[c.port] {
+				seen[c.port] = true
+				unique = append(unique, c)
+			}
+		}
+		fmt.Println()
+		fmt.Println("Port conflicts detected:")
+		for _, c := range unique {
+			if c.pid > 0 {
+				fmt.Printf("  Port %d in use by %s (PID %d)  %s kill %d\n", c.port, c.process, c.pid, yellow("→"), c.pid)
+			} else {
+				fmt.Printf("  Port %d in use by %s\n", c.port, c.process)
+			}
+		}
+	}
+
 	updateWg.Wait()
 	if updateHint != "" {
 		fmt.Print(updateHint)
@@ -241,6 +287,48 @@ func extractDialAddr(proxyURL string) string {
 		}
 	}
 	return net.JoinHostPort(host, port)
+}
+
+// extractPort returns the numeric port from a "host:port" string, or 0 if unparsable.
+func extractPort(addr string) int {
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0
+	}
+	return p
+}
+
+// portConflict records a port held by another process.
+type portConflict struct {
+	port    int
+	process string
+	pid     int
+}
+
+// diagnosePort checks who holds a port and returns a status suffix and optional conflict.
+// Results are cached in the provided map to avoid duplicate lsof calls.
+func diagnosePort(port int, cache map[int]*daemon.PortInfo) (string, *portConflict) {
+	if port == 0 {
+		return "", nil
+	}
+	info, cached := cache[port]
+	if !cached {
+		var err error
+		info, err = daemon.CheckPort(port)
+		if err != nil {
+			return "", nil
+		}
+		cache[port] = info
+	}
+	if info == nil {
+		return fmt.Sprintf(" (not listening on :%d)", port), nil
+	}
+	conflict := &portConflict{port: port, process: info.Process, pid: info.PID}
+	return fmt.Sprintf(" (port :%d in use by %s)", port, info), conflict
 }
 
 // resolveDomain returns the full domain for a service, prepending the

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -46,10 +46,20 @@ hatch doctor    # check "Root CA trusted" status
 
 ### Port Conflicts
 
-**Symptoms:** `hatch up` fails with a message like `port 80 is already in use by nginx (PID 1234); stop that process first`. Or `hatch doctor` reports ports unavailable.
+**Symptoms:** `hatch up` fails with a message like `port 80 is already in use by nginx (PID 1234); stop that process first`. Or `hatch doctor` reports ports unavailable. Or `hatch status` shows a service as unhealthy with a port conflict.
+
+**Diagnosis:**
+
+`hatch status` automatically checks ports when a service is unhealthy or the daemon is not running. It shows the process name, PID, and a suggested `kill` command:
+```
+Port conflicts detected:
+  Port 3000 in use by node (PID 12345)  → kill 12345
+```
+
+You can also run `hatch doctor` for a full system check.
 
 **Fixes:**
-- Stop the process named in the error, then run `hatch up` again
+- Kill the process shown in the conflict summary, then run `hatch up` again
 - Or change Hatch's ports in `~/.hatch/config.yml`:
   ```yaml
   settings:
@@ -107,11 +117,12 @@ hatch doctor    # check launchd plist status
 
 ### Service Showing as Unhealthy
 
-**Symptoms:** Dashboard or `hatch status` shows a red health indicator.
+**Symptoms:** Dashboard or `hatch status` shows a red health indicator. The status line includes a diagnostic hint like `unhealthy (not listening on :3000)` or `unhealthy (port :3000 in use by node, PID 12345)`.
 
 **Fixes:**
+- If the hint says "not listening", your dev server is not running. Start it on the configured port.
+- If the hint names a process and PID, that process is holding the port. Kill it or reconfigure your service to use a different port.
 - Visit the domain in your browser. If the upstream is down, Hatch shows a 502 error page with the configured upstream address and a checklist of things to verify.
-- Make sure your local dev server is actually running on the configured port
 - Check the proxy URL in your config matches your dev server's address
 - View logs for details: `hatch logs -f`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,7 +32,7 @@ hatch restart
 
 ### `hatch status`
 
-Show daemon state, project list, and service health.
+Show daemon state, project list, and service health. When a service is unhealthy, the output includes a diagnosis: whether the port is free (nothing listening) or held by another process (with process name and PID). If port conflicts are detected, a summary with suggested `kill` commands is printed at the end.
 
 ```bash
 hatch status

--- a/internal/daemon/port.go
+++ b/internal/daemon/port.go
@@ -58,7 +58,7 @@ func parseLsofOutput(output string, port int) *PortInfo {
 		if len(fields) < 2 {
 			continue
 		}
-		name := fields[0]
+		name := sanitizeProcessName(fields[0])
 		pid, err := strconv.Atoi(fields[1])
 		if err != nil {
 			return &PortInfo{Process: name}
@@ -66,4 +66,19 @@ func parseLsofOutput(output string, port int) *PortInfo {
 		return &PortInfo{Process: name, PID: pid}
 	}
 	return nil
+}
+
+// sanitizeProcessName strips terminal control characters from a process name
+// to prevent escape-sequence injection via crafted binary names.
+func sanitizeProcessName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == 0x1b || (r < 0x20 && r != '\t') || r == 0x7f {
+			b.WriteRune('?')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/internal/daemon/port_test.go
+++ b/internal/daemon/port_test.go
@@ -63,6 +63,13 @@ func TestParseLsofOutput(t *testing.T) {
 			port: 443,
 			want: &PortInfo{Process: "nginx", PID: 1234},
 		},
+		{
+			name: "control characters in process name are sanitized",
+			output: "COMMAND  PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\n" +
+				"\x1b[31mevil\x1b[0m   999   root    6u  IPv4  12345      0t0  TCP *:80 (LISTEN)\n",
+			port: 80,
+			want: &PortInfo{Process: "?[31mevil?[0m", PID: 999},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- When a service is unhealthy, `hatch status` now diagnoses why: port is free ("not listening on :3000") or held by another process ("port :3000 in use by node, PID 12345")
- When the daemon is not running, checks HTTP/HTTPS ports for blockers and prints them inline
- Prints a deduplicated conflict summary with `kill` commands at the end of output
- Sanitizes lsof process names to prevent terminal escape-sequence injection
- Caches port check results to avoid duplicate lsof calls across services sharing a port

## Test plan

- [ ] Start a process on a port (`python3 -m http.server 3000`), configure a service proxying to it, kill the python process, run `hatch status` -- should show "not listening on :3000"
- [ ] Start a rogue process on a configured port, run `hatch status` -- should show process name and PID
- [ ] Stop the daemon, start something on port 80, run `hatch status` -- should show port 80 blocker under daemon info
- [ ] `go vet ./...` and `go test ./...` pass