### PR TITLE
Fix tray menu clicks lost during periodic refresh

### DIFF
--- a/internal/tray/manager.go
+++ b/internal/tray/manager.go
@@ -164,6 +164,7 @@ func (m *Manager) refresh() {
 	cfg, daemonRunning, daemonVersion, statuses := m.fetchState()
 	if m.needsRebuild(cfg) {
 		m.rebuildMenu(cfg, daemonRunning, daemonVersion, statuses)
+		m.menu.Update() // Push structural changes to the native NSMenu.
 	} else {
 		m.updateLabels(cfg, daemonRunning, daemonVersion, statuses)
 	}
@@ -352,7 +353,6 @@ func (m *Manager) rebuildMenu(cfg config.Config, daemonRunning bool, daemonVersi
 
 	m.prevProjectNames = projectNames
 	m.menuBuilt = true
-	m.menu.Update()
 }
 
 // updateLabels updates menu item labels and visibility in place without


### PR DESCRIPTION
Closes #56

## Summary

- `populateMenu()` called `Clear()` every 5 seconds, destroying all native NSMenuItems and their click handlers. Clicks landing during the rebuild window were delivered to deallocated items and silently dropped.
- Split into `rebuildMenu()` (structural changes only) and `updateLabels()` (in-place updates via `SetLabel`/`SetHidden`). Full rebuilds only happen when projects or services are added or removed.
- `toggleProject` now reads fresh config state at click time instead of relying on a stale closure captured at poll time.
- Added a shutdown guard in `refresh()` to prevent menu operations racing with `tray.Destroy()`.
- Capped daemon version string length as defense-in-depth.
- Replaced hand-rolled `slicesEqual` and `sort.Strings` with stdlib `slices.Equal`/`slices.Sort`.

## Test plan

- [ ] Launch tray, open menu, wait for refresh cycle, click "Open Dashboard" registers on first attempt
- [ ] Health dots update every 5 seconds without menu flicker
- [ ] Add a project to config while tray is running, appears on next refresh
- [ ] Remove a project, disappears on next refresh
- [ ] Stop daemon via menu, "Start Hatch" appears, "Restart"/"Stop" hide
- [ ] Start daemon via menu, reverses
- [ ] Toggle project enable/disable, dot and label change correctly
- [ ] `go vet ./...` and `go test ./...` pass