### PR TITLE
Add start/stop as aliases for up/down

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -12,7 +12,8 @@ import (
 )
 
 var downCmd = &cobra.Command{
-	Use:   "down",
+	Use:     "down",
+	Aliases: []string{"stop"},
 	Short: "Stop the Hatch daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDown()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,8 @@ import (
 )
 
 var upCmd = &cobra.Command{
-	Use:   "up",
+	Use:     "up",
+	Aliases: []string{"start"},
 	Short: "Start the Hatch daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runUp()


### PR DESCRIPTION
## Summary

Closes #60.

- `hatch start` is now an alias for `hatch up`
- `hatch stop` is now an alias for `hatch down`

Uses Cobra's built-in `Aliases` field, same pattern as `list`/`ls`, `remove`/`rm`, and `clean`/`uninstall`.

## Test plan

- [ ] `hatch start` starts the daemon
- [ ] `hatch stop` stops the daemon
- [ ] `hatch up` and `hatch down` still work as before
- [ ] `hatch --help` shows the aliases
- [ ] CI passes