### PR TITLE
Fix linked projects not appearing in dashboard

### DIFF
--- a/frontend/src/hooks/use-projects.ts
+++ b/frontend/src/hooks/use-projects.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as api from "@/api";
 import type { Project } from "@/types";
 
@@ -6,6 +6,7 @@ export function useProjects() {
   const [projects, setProjects] = useState<Record<string, Project>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const refresh = useCallback(async () => {
     try {
@@ -21,6 +22,10 @@ export function useProjects() {
 
   useEffect(() => {
     refresh();
+    intervalRef.current = setInterval(refresh, 10_000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
   }, [refresh]);
 
   const add = useCallback(


### PR DESCRIPTION
## Summary

Closes #64.

The dashboard's `useProjects` hook fetched the project list once on mount but never polled for updates. The tray app hides the dashboard window on close rather than destroying it, so the React tree stays mounted with stale state. When a user ran `hatch link` and then re-opened the dashboard, the newly linked project was missing because no re-fetch occurred.

The tray menu worked because it polls `LoadWithProjectConfigs()` from disk every 5 seconds.

Fix: add 10-second polling to `useProjects`, matching the existing pattern in `useHealth`, `useProcesses`, and `useTunnels`.

## Test plan

- [ ] Run `hatch link` in a project directory while the dashboard is open; project appears within 10 seconds
- [ ] Close dashboard, run `hatch link`, re-open dashboard; project appears
- [ ] Existing projects still render correctly
- [ ] CI passes