### PR TITLE
Add per-service working directory for managed commands

### DIFF
--- a/docs/advanced/how-it-works.md
+++ b/docs/advanced/how-it-works.md
@@ -213,7 +213,7 @@ Services with a `command` field are managed as supervised processes.
 
 **Exponential backoff:** Restarts begin at 1 second and double up to a maximum of 30 seconds. The backoff resets after the process has been running stably for 60 seconds.
 
-**Command execution:** Commands are run via `sh -c` in the project's `path` directory. Each command runs in its own process group so that child processes are cleaned up on stop.
+**Command execution:** Commands are run via `sh -c` in the project's `path` directory. When a service sets `dir`, the command runs in that subdirectory instead (resolved relative to `path`). Each command runs in its own process group so that child processes are cleaned up on stop.
 
 **Graceful shutdown:** On stop, Hatch sends `SIGTERM` to the process group, waits up to 5 seconds, then sends `SIGKILL` if the process is still running.
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -31,7 +31,7 @@ The main view shows all your projects in a grid layout. Each project card displa
 - Service list with proxy targets and subdomain labels
 - Health indicators (green = healthy, red = unreachable)
 
-You can **add**, **edit**, and **delete** projects directly from the dashboard using dialog forms. The add and edit dialogs support `command` and `env_file` fields for process management. Proxy is optional when a command is set.
+You can **add**, **edit**, and **delete** projects directly from the dashboard using dialog forms. The add and edit dialogs support `command`, `dir`, and `env_file` fields for process management. Proxy is optional when a command is set.
 
 ### Process Status
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -41,6 +41,7 @@ projects:
       worker:
         proxy: http://localhost:3000
         command: npm run worker
+        dir: packages/worker
         env_file: .env.worker
       tasks:
         command: npm run tasks
@@ -201,6 +202,17 @@ A shell command to run for this service. Hatch supervises the process with expon
 command: npm run dev
 ```
 
+### `services.<name>.dir`
+
+- **Type:** `string`
+- **Optional**
+
+Working directory for the command. Must be a relative path (resolved from the project's `path` directory). If not set, the command runs in the project's `path`.
+
+```yaml
+dir: packages/api
+```
+
 ### `services.<name>.env_file`
 
 - **Type:** `string`
@@ -247,5 +259,7 @@ See [Tunnels](/guide/tunnels) for a full guide.
 - Service `proxy` must be a valid URL
 - Service `subdomain` must be a valid DNS label
 - `route` and `subdomain` require `proxy`
+- `dir` must be a relative path without `..`
+- `dir` requires `command`
 - `tunnel` requires `proxy`
 - `settings.cloudflare_account_id`, when set, must be a 32-character hex string

--- a/docs/reference/hatch-yml.md
+++ b/docs/reference/hatch-yml.md
@@ -10,6 +10,7 @@ services:
   <service-name>:
     proxy: <upstream-url>        # required unless command is set
     command: <shell-command>      # optional
+    dir: <relative-path>         # optional
     env_file: <path>             # optional
     route: <path-prefix>         # optional
     subdomain: <subdomain>       # optional
@@ -135,6 +136,26 @@ services:
 Produces:
 - `https://myapp.test` → `http://localhost:3000` (process managed by Hatch)
 - `worker` runs as a supervised process with no proxy route
+
+### Monorepo
+
+```yaml
+domain: myapp.test
+services:
+  api:
+    proxy: http://localhost:8080
+    command: npm run dev
+    dir: packages/api
+    subdomain: api
+  web:
+    proxy: http://localhost:3000
+    command: npm run dev
+    dir: packages/web
+```
+
+Produces:
+- `https://myapp.test` → `http://localhost:3000` (runs `npm run dev` in `packages/web`)
+- `https://api.myapp.test` → `http://localhost:8080` (runs `npm run dev` in `packages/api`)
 
 ### Tunnel Support
 

--- a/frontend/src/components/add-project-dialog.tsx
+++ b/frontend/src/components/add-project-dialog.tsx
@@ -27,6 +27,7 @@ function emptyForm() {
     serviceName: "web",
     proxy: "localhost:3000",
     command: "",
+    dir: "",
     envFile: "",
     route: "",
     subdomain: "",
@@ -95,6 +96,7 @@ export function AddProjectDialog({
         [form.serviceName]: {
           ...(form.proxy ? { proxy: form.proxy } : {}),
           ...(form.command ? { command: form.command } : {}),
+          ...(form.dir ? { dir: form.dir } : {}),
           ...(form.envFile ? { env_file: form.envFile } : {}),
           ...(form.route ? { route: form.route } : {}),
           ...(form.subdomain ? { subdomain: form.subdomain } : {}),
@@ -185,6 +187,17 @@ export function AddProjectDialog({
                 />
               </div>
               <div className="space-y-2">
+                <Label htmlFor="dir">Working directory</Label>
+                <Input
+                  id="dir"
+                  value={form.dir}
+                  onChange={(e) => set("dir", e.target.value)}
+                  placeholder="packages/api"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-2">
                 <Label htmlFor="env-file">Env file</Label>
                 <Input
                   id="env-file"
@@ -193,8 +206,6 @@ export function AddProjectDialog({
                   placeholder=".env"
                 />
               </div>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
                 <Label htmlFor="route">Route</Label>
                 <Input
@@ -204,6 +215,8 @@ export function AddProjectDialog({
                   placeholder="/api/*"
                 />
               </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
               <div className="space-y-2">
                 <Label htmlFor="subdomain">Subdomain</Label>
                 <Input

--- a/frontend/src/components/edit-project-dialog.tsx
+++ b/frontend/src/components/edit-project-dialog.tsx
@@ -27,6 +27,7 @@ interface ServiceForm {
   name: string;
   proxy: string;
   command: string;
+  dir: string;
   envFile: string;
   route: string;
   subdomain: string;
@@ -38,6 +39,7 @@ function serviceToForm(name: string, svc: Service): ServiceForm {
     name,
     proxy: svc.proxy ?? "",
     command: svc.command ?? "",
+    dir: svc.dir ?? "",
     envFile: svc.env_file ?? "",
     route: svc.route ?? "",
     subdomain: svc.subdomain ?? "",
@@ -78,7 +80,7 @@ export function EditProjectDialog({
   function addService() {
     setServices((prev) => [
       ...prev,
-      { name: "", proxy: "localhost:3000", command: "", envFile: "", route: "", subdomain: "", websocket: false },
+      { name: "", proxy: "localhost:3000", command: "", dir: "", envFile: "", route: "", subdomain: "", websocket: false },
     ]);
   }
 
@@ -122,6 +124,7 @@ export function EditProjectDialog({
       svcMap[s.name] = {
         ...(s.proxy ? { proxy: s.proxy } : {}),
         ...(s.command ? { command: s.command } : {}),
+        ...(s.dir ? { dir: s.dir } : {}),
         ...(s.envFile ? { env_file: s.envFile } : {}),
         ...(s.route ? { route: s.route } : {}),
         ...(s.subdomain ? { subdomain: s.subdomain } : {}),
@@ -233,6 +236,16 @@ export function EditProjectDialog({
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1">
+                    <Label className="text-xs">Working directory</Label>
+                    <Input
+                      value={svc.dir}
+                      onChange={(e) =>
+                        updateService(idx, { dir: e.target.value })
+                      }
+                      placeholder="packages/api"
+                    />
+                  </div>
+                  <div className="space-y-1">
                     <Label className="text-xs">Env file</Label>
                     <Input
                       value={svc.envFile}
@@ -242,6 +255,8 @@ export function EditProjectDialog({
                       placeholder=".env"
                     />
                   </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1">
                     <Label className="text-xs">Route</Label>
                     <Input
@@ -252,8 +267,6 @@ export function EditProjectDialog({
                       placeholder="/api/*"
                     />
                   </div>
-                </div>
-                <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1">
                     <Label className="text-xs">Subdomain</Label>
                     <Input
@@ -264,6 +277,8 @@ export function EditProjectDialog({
                       placeholder="api"
                     />
                   </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
                   <div className="flex items-end gap-2 pb-1">
                     <Switch
                       checked={svc.websocket}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,7 @@ export interface Service {
   subdomain?: string;
   websocket?: boolean;
   command?: string;
+  dir?: string;
   env_file?: string;
   tunnel?: string;
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -73,6 +73,7 @@ func (t *TunnelValue) UnmarshalJSON(data []byte) error {
 type Service struct {
 	Proxy     string      `yaml:"proxy,omitempty" json:"proxy,omitempty"`
 	Command   string      `yaml:"command,omitempty" json:"command,omitempty"`
+	Dir       string      `yaml:"dir,omitempty" json:"dir,omitempty"`
 	Route     string      `yaml:"route,omitempty" json:"route,omitempty"`
 	Subdomain string      `yaml:"subdomain,omitempty" json:"subdomain,omitempty"`
 	WebSocket bool        `yaml:"websocket,omitempty" json:"websocket,omitempty"`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -176,6 +176,20 @@ func validateService(prefix, name string, s Service) []error {
 		errs = append(errs, fmt.Errorf("%s.subdomain %q must be a valid hostname label", svcPrefix, s.Subdomain))
 	}
 
+	// Dir must be a relative path without traversal (resolved against project path).
+	if s.Dir != "" {
+		if filepath.IsAbs(s.Dir) {
+			errs = append(errs, fmt.Errorf("%s.dir must be a relative path, got %q", svcPrefix, s.Dir))
+		} else if strings.Contains(s.Dir, "..") {
+			errs = append(errs, fmt.Errorf("%s.dir must not contain '..', got %q", svcPrefix, s.Dir))
+		}
+	}
+
+	// Dir requires command.
+	if s.Dir != "" && s.Command == "" {
+		errs = append(errs, fmt.Errorf("%s.dir requires command to be set", svcPrefix))
+	}
+
 	// EnvFile must be a relative path without traversal.
 	if s.EnvFile != "" {
 		if filepath.IsAbs(s.EnvFile) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -386,6 +386,43 @@ func TestValidate_ServiceEnvFile(t *testing.T) {
 	}
 }
 
+func TestValidate_ServiceDir(t *testing.T) {
+	tests := []struct {
+		name    string
+		dir     string
+		wantErr string
+	}{
+		{"relative path", "packages/api", ""},
+		{"simple subdir", "src", ""},
+		{"absolute path", "/usr/local/app", "must be a relative path"},
+		{"parent traversal", "../other", "must not contain '..'"},
+		{"nested traversal", "packages/../../other", "must not contain '..'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			p := cfg.Projects["myapp"]
+			p.Services = map[string]Service{"web": {Command: "npm start", Dir: tt.dir}}
+			cfg.Projects["myapp"] = p
+			errs := Validate(cfg)
+			if tt.wantErr != "" {
+				requireError(t, errs, tt.wantErr)
+			} else if len(errs) != 0 {
+				t.Errorf("expected no errors, got %v", errs)
+			}
+		})
+	}
+}
+
+func TestValidate_ServiceDirRequiresCommand(t *testing.T) {
+	cfg := validConfig()
+	p := cfg.Projects["myapp"]
+	p.Services = map[string]Service{"web": {Proxy: "http://localhost:3000", Dir: "packages/web"}}
+	cfg.Projects["myapp"] = p
+	errs := Validate(cfg)
+	requireError(t, errs, "dir requires command")
+}
+
 func requireError(t *testing.T, errs []error, substr string) {
 	t.Helper()
 	for _, err := range errs {

--- a/internal/process/manager.go
+++ b/internal/process/manager.go
@@ -326,9 +326,22 @@ func (m *Manager) buildDesired(appCfg config.Config) map[ServiceID]desiredProces
 				}
 			}
 
+			dir := proj.Path
+			if svc.Dir != "" {
+				dir = filepath.Clean(filepath.Join(proj.Path, svc.Dir))
+				if proj.Path != "" && !strings.HasPrefix(dir, filepath.Clean(proj.Path)+string(filepath.Separator)) {
+					log.Warn().
+						Str("project", projName).
+						Str("service", svcName).
+						Str("dir", svc.Dir).
+						Msg("dir path escapes project directory, using project path")
+					dir = proj.Path
+				}
+			}
+
 			desired[id] = desiredProcess{
 				command: svc.Command,
-				dir:     proj.Path,
+				dir:     dir,
 				env:     deduplicateEnv(env),
 			}
 		}


### PR DESCRIPTION
## Summary

- Add optional `dir` field to service config for setting the working directory of managed commands
- Relative paths resolve against the project's `path`; absolute paths and `..` traversal are rejected
- Runtime containment guard prevents directory escape (matches the existing `env_file` pattern)
- Dashboard add/edit dialogs include a "Working directory" field
- Docs updated: config reference, hatch.yml reference, how-it-works, dashboard guide

Closes #69

## Example

```yaml
projects:
  myapp:
    path: /Users/me/projects/myapp
    services:
      api:
        command: npm run dev
        dir: packages/api
        proxy: http://localhost:8080
      web:
        command: npm run dev
        dir: packages/web
        proxy: http://localhost:3000
```

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] TypeScript compiles (`tsc --noEmit`)
- [ ] Manual: configure a service with `dir`, verify command runs in the subdirectory
- [ ] Manual: verify validation rejects absolute paths and `..` traversal
- [ ] Manual: verify dashboard add/edit dialogs show the dir field