### PR TITLE
Increase daemon startup wait timeout to 15s

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -125,7 +125,7 @@ func runUp() error {
 
 // waitForDaemon polls the daemon API until it responds or the timeout expires.
 func waitForDaemon() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	client := &http.Client{}


### PR DESCRIPTION
## Summary
- Increase `waitForDaemon` timeout from 5s to 15s
- With Cloudflare API calls for tunnel domain resolution at startup, the daemon can exceed 5 seconds before the API server starts
- This caused false "daemon failed to start" errors even though the daemon started successfully

## Test plan
- [x] `go vet ./cmd/...` clean
- [x] Build succeeds
- [ ] Manual: `hatch restart` completes without false failure