### PR TITLE
Stop tray app during down, restart, and clean

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -45,7 +45,8 @@ func runClean(cmd *cobra.Command, args []string) error {
 
 	anyCleaned := false
 
-	// Step 1: Stop daemon
+	// Step 1: Stop tray and daemon
+	stopTray()
 	if daemon.IsLoaded() {
 		if err := daemon.UninstallPlist(); err != nil {
 			fmt.Printf("  %s Failed to remove daemon plist: %v\n", red("✗"), err)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -2,19 +2,26 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"time"
 
 	"github.com/fatih/color"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
+	"github.com/httphatch/hatch/internal/config"
 	"github.com/httphatch/hatch/internal/daemon"
 )
 
 var downCmd = &cobra.Command{
 	Use:     "down",
 	Aliases: []string{"stop"},
-	Short: "Stop the Hatch daemon",
+	Short:   "Stop the Hatch daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDown()
 	},
@@ -26,6 +33,9 @@ func runDown() error {
 		fmt.Printf("%s is not running\n", color.CyanString("Hatch"))
 		return nil
 	}
+
+	// Stop the tray app first so it doesn't try to restart the daemon.
+	stopTray()
 
 	// Remove plist first so KeepAlive cannot respawn the process.
 	if err := daemon.UninstallPlist(); err != nil {
@@ -53,6 +63,42 @@ func runDown() error {
 
 	fmt.Printf("%s stopped\n", color.New(color.FgCyan, color.Bold).Sprint("Hatch"))
 	return nil
+}
+
+// stopTray verifies the tray is running via its flock, reads the PID, and
+// sends SIGTERM. The flock check prevents signaling a recycled PID.
+func stopTray() {
+	lockPath := filepath.Join(config.Dir(), "tray.lock")
+	f, err := os.Open(lockPath)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	// Try to acquire the lock. If we get it, no tray is running.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err == nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		return
+	}
+
+	// Lock is held by the tray process. Read PID from the locked fd.
+	data, err := io.ReadAll(io.LimitReader(f, 32))
+	if err != nil {
+		return
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		log.Debug().Err(err).Int("pid", pid).Msg("could not signal tray process")
+		return
+	}
+	log.Debug().Int("pid", pid).Msg("sent SIGTERM to tray")
 }
 
 func init() {

--- a/cmd/tray_darwin.go
+++ b/cmd/tray_darwin.go
@@ -173,6 +173,19 @@ func acquireTrayLock() (*os.File, error) {
 		_ = f.Close()
 		return nil, err
 	}
+	// Write PID so other commands can find and signal this process.
+	if err := f.Truncate(0); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("truncate tray lock: %w", err)
+	}
+	if _, err := fmt.Fprintf(f, "%d\n", os.Getpid()); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("write tray pid: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("sync tray lock: %w", err)
+	}
 	return f, nil
 }
 

--- a/docs/src/content/docs/advanced/architecture.md
+++ b/docs/src/content/docs/advanced/architecture.md
@@ -112,11 +112,11 @@ A plist file is installed at `~/Library/LaunchAgents/dev.hatch.daemon.plist`:
 | RunAtLoad | `true` if `auto_start` enabled |
 | KeepAlive | `true` if `auto_start` enabled |
 
-`hatch up` installs and loads the plist. `hatch down` unloads it.
+`hatch up` installs and loads the plist. `hatch down` unloads it and stops the tray app.
 
 ### Tray process
 
-The system tray app runs as a separate process (`hatch _tray`). `hatch up` spawns it automatically when `tray_icon` is enabled. The tray communicates with the daemon over the local HTTP API at `127.0.0.1:42824`. A file lock at `~/.hatch/tray.lock` prevents duplicate tray instances.
+The system tray app runs as a separate process (`hatch _tray`). `hatch up` spawns it automatically when `tray_icon` is enabled. The tray communicates with the daemon over the local HTTP API at `127.0.0.1:42824`. A file lock at `~/.hatch/tray.lock` prevents duplicate tray instances and stores the tray PID so that `hatch down` can send SIGTERM to stop it.
 
 ### Startup sequence
 

--- a/docs/src/content/docs/guides/dashboard.md
+++ b/docs/src/content/docs/guides/dashboard.md
@@ -79,7 +79,7 @@ Changes in General are saved to `config.yml` and the daemon reloads automaticall
 
 ## Tray icon
 
-The tray icon in the macOS menu bar provides quick access to all running projects and daemon controls. The tray runs as a separate process from the daemon, so it stays visible when the daemon stops.
+The tray icon in the macOS menu bar provides quick access to all running projects and daemon controls. The tray runs as a separate process from the daemon. Running `hatch down` or `hatch restart` stops both the daemon and the tray. Running `hatch up` or `hatch restart` relaunches the tray automatically when `tray_icon` is enabled.
 
 Menu items:
 - **Open Dashboard** — shows the dashboard window

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -22,9 +22,9 @@ hatch up
 
 ### `hatch down`
 
-Stop the Hatch daemon.
+Stop the Hatch daemon and tray app.
 
-Unloads the launchd plist and stops the daemon gracefully.
+Unloads the launchd plist, stops the daemon gracefully, and terminates the tray app if running.
 
 ```bash
 hatch down
@@ -32,7 +32,7 @@ hatch down
 
 ### `hatch restart`
 
-Restart the daemon (stops then starts).
+Restart the daemon and tray app (stops then starts).
 
 ```bash
 hatch restart


### PR DESCRIPTION
## Summary
- `hatch down`, `hatch restart`, and `hatch clean` now stop the tray app before stopping the daemon
- The tray writes its PID to `tray.lock` so `stopTray()` can find it
- Flock-based liveness check prevents signaling a recycled PID (matches the daemon's `IsRunning()` pattern)
- Docs updated for CLI reference, dashboard guide, and architecture page

## Test plan
- [ ] Run `hatch up` with `tray_icon: true`, verify tray appears
- [ ] Run `hatch down`, verify both daemon and tray stop
- [ ] Run `hatch restart`, verify both restart with new binary
- [ ] Run `hatch clean`, verify tray is stopped before cleanup
- [ ] Kill tray with `kill -9`, run `hatch down`, verify no error (stale PID handled)

Fixes #86