### PR TITLE
Restrict TLD setting to safe non-public TLDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ docs:
 define DEV_CONFIG
 version: 1
 settings:
-  tld: dev
+  tld: internal
   http_port: 8080
   https_port: 8443
   api_port: 42825

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -64,15 +64,27 @@ func runClean(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s Daemon not running\n", green("✓"))
 	}
 
-	// Step 2: Remove DNS resolver
-	if dns.IsResolverInstalled(tld) {
-		if err := dns.RemoveResolverFile(&sudoRunner{}, tld); err != nil {
-			fmt.Printf("  %s Failed to remove DNS resolver: %v\n", red("✗"), err)
-			os.Exit(1)
+	// Step 2: Remove DNS resolver (including formerly-allowed TLDs like "dev"
+	// that may have left orphaned resolver files).
+	resolverTLDs := []string{tld}
+	for _, old := range []string{"dev"} {
+		if old != tld {
+			resolverTLDs = append(resolverTLDs, old)
 		}
-		fmt.Printf("  %s DNS resolver removed\n", green("✓"))
-		anyCleaned = true
-	} else {
+	}
+	removedResolver := false
+	for _, t := range resolverTLDs {
+		if dns.IsResolverInstalled(t) {
+			if err := dns.RemoveResolverFile(&sudoRunner{}, t); err != nil {
+				fmt.Printf("  %s Failed to remove DNS resolver for .%s: %v\n", red("✗"), t, err)
+				os.Exit(1)
+			}
+			fmt.Printf("  %s DNS resolver removed (.%s)\n", green("✓"), t)
+			anyCleaned = true
+			removedResolver = true
+		}
+	}
+	if !removedResolver {
 		fmt.Printf("  %s DNS resolver not installed\n", green("✓"))
 	}
 

--- a/docs/src/content/docs/concepts/domains-and-dns.md
+++ b/docs/src/content/docs/concepts/domains-and-dns.md
@@ -35,8 +35,10 @@ The default TLD is `test`, which is an IANA-reserved TLD that will never be used
 
 ```yaml
 settings:
-  tld: test  # also supports: localhost, local, dev
+  tld: test  # also supports: localhost, local, internal
 ```
+
+Only TLDs reserved for local use are allowed: `test`, `localhost`, `local`, and `internal`. Public TLDs like `dev` or `app` are rejected because the macOS resolver file would hijack all DNS queries for that TLD system-wide, breaking real websites.
 
 Changing the TLD updates the resolver file, DNS server, and all project domains.
 

--- a/docs/src/content/docs/contributing/development-setup.md
+++ b/docs/src/content/docs/contributing/development-setup.md
@@ -59,7 +59,7 @@ Set these values to avoid conflicts with the production daemon:
 ```yaml
 version: 1
 settings:
-  tld: dev
+  tld: internal
   http_port: 8080
   https_port: 8443
   api_port: 42825
@@ -105,7 +105,7 @@ make dev-down
 - `HATCH_HOME` env var redirects all config, certs, logs, and state files to `~/.hatch-dev/`
 - `api_port`, `dns_port`, and `caddy_admin_port` settings override the hardcoded defaults
 - The launchd label is derived from `HATCH_HOME` so each instance gets its own launchd job
-- A different `tld` (e.g., `dev` instead of `test`) creates a separate `/etc/resolver/` file
+- A different `tld` (e.g., `internal` instead of `test`) creates a separate `/etc/resolver/` file
 
 ## Running tests
 

--- a/docs/src/content/docs/reference/config-yml.md
+++ b/docs/src/content/docs/reference/config-yml.md
@@ -72,7 +72,7 @@ Config schema version. Must be `1`.
 
 - **Type:** `string`
 - **Default:** `test`
-- **Allowed:** `test`, `localhost`, `local`, `dev`
+- **Allowed:** `test`, `localhost`, `local`, `internal`
 
 The top-level domain used for all project domains. See [Domains and DNS](/docs/concepts/domains-and-dns) for how the TLD affects DNS resolution.
 

--- a/frontend/src/components/settings-form.tsx
+++ b/frontend/src/components/settings-form.tsx
@@ -18,7 +18,7 @@ import { ErrorState } from "@/components/error-state";
 import { useSettings } from "@/hooks/use-settings";
 import type { Settings } from "@/types";
 
-const TLD_OPTIONS = ["test", "localhost", "local", "dev"];
+const TLD_OPTIONS = ["test", "localhost", "local", "internal"];
 const LOG_LEVEL_OPTIONS = ["debug", "info", "warn", "error"];
 
 export function SettingsForm() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,7 +65,7 @@ func TestEnsureConfigFile_DoesNotOverwrite(t *testing.T) {
 	}
 
 	// Write a custom config
-	custom := []byte("version: 1\nsettings:\n  tld: dev\n  http_port: 80\n  https_port: 443\n  auto_start: false\n  log_level: debug\nprojects: {}\n")
+	custom := []byte("version: 1\nsettings:\n  tld: internal\n  http_port: 80\n  https_port: 443\n  auto_start: false\n  log_level: debug\nprojects: {}\n")
 	path := filepath.Join(home, configFileName)
 	if err := os.WriteFile(path, custom, 0644); err != nil {
 		t.Fatal(err)

--- a/internal/config/errors_test.go
+++ b/internal/config/errors_test.go
@@ -21,7 +21,7 @@ func TestValidationErrors_SingleError(t *testing.T) {
 func TestValidationErrors_MultipleErrors(t *testing.T) {
 	ve := &ValidationErrors{Errs: []error{
 		fmt.Errorf("version must be 1"),
-		fmt.Errorf("settings.tld must be one of: test, localhost, local, dev"),
+		fmt.Errorf("settings.tld must be one of: test, localhost, local, internal"),
 	}}
 	got := ve.Error()
 	if !strings.HasPrefix(got, "2 config errors:") {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -29,11 +29,23 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("parsing config: %w", &ValidationErrors{Errs: errs})
 	}
 
+	migrateTLD(&cfg)
+
 	if errs := Validate(cfg); len(errs) > 0 {
 		return Config{}, fmt.Errorf("invalid config: %w", &ValidationErrors{Errs: errs})
 	}
 
 	return cfg, nil
+}
+
+// migrateTLD rewrites formerly-allowed TLDs that are now rejected.
+// ".dev" is a real public gTLD; using it as a local TLD hijacks all
+// .dev DNS queries system-wide via the macOS resolver file.
+func migrateTLD(cfg *Config) {
+	if cfg.Settings.TLD == "dev" {
+		log.Warn().Msg("tld \"dev\" is a public gTLD and is no longer allowed; migrating to \"internal\"")
+		cfg.Settings.TLD = "internal"
+	}
 }
 
 // Save atomically writes cfg to ConfigFile().
@@ -140,10 +152,10 @@ func MergeAllProjectConfigs(cfg *Config) {
 }
 
 // normalizeDomainTLD rewrites a domain's TLD to match the configured TLD.
-// For example, "demo.test" becomes "demo.dev" when the TLD is "dev".
+// For example, "demo.test" becomes "demo.internal" when the TLD is "internal".
 // If the domain doesn't end with a known TLD, it's returned unchanged.
 func normalizeDomainTLD(domain, tld string) string {
-	for _, knownTLD := range []string{"test", "localhost", "local", "dev"} {
+	for _, knownTLD := range []string{"test", "localhost", "local", "internal"} {
 		suffix := "." + knownTLD
 		if strings.HasSuffix(domain, suffix) {
 			if knownTLD == tld {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -17,7 +17,7 @@ var allowedTLDs = map[string]bool{
 	"test":      true,
 	"localhost": true,
 	"local":     true,
-	"dev":       true,
+	"internal":  true,
 }
 
 var allowedLogLevels = map[string]bool{
@@ -53,7 +53,7 @@ func validateSettings(s Settings) []error {
 	var errs []error
 
 	if !allowedTLDs[s.TLD] {
-		errs = append(errs, fmt.Errorf("settings.tld must be one of: test, localhost, local, dev; got %q", s.TLD))
+		errs = append(errs, fmt.Errorf("settings.tld must be one of: test, localhost, local, internal; got %q", s.TLD))
 	}
 
 	if s.HTTPPort < 1 || s.HTTPPort > 65535 {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -47,7 +47,7 @@ func TestValidate_Version(t *testing.T) {
 }
 
 func TestValidate_TLD(t *testing.T) {
-	for _, tld := range []string{"test", "localhost", "local", "dev"} {
+	for _, tld := range []string{"test", "localhost", "local", "internal"} {
 		cfg := validConfig()
 		cfg.Settings.TLD = tld
 		cfg.Projects["myapp"] = Project{
@@ -60,10 +60,13 @@ func TestValidate_TLD(t *testing.T) {
 		}
 	}
 
-	cfg := validConfig()
-	cfg.Settings.TLD = "com"
-	errs := Validate(cfg)
-	requireError(t, errs, "settings.tld must be one of")
+	// Public TLDs must be rejected to avoid hijacking real DNS.
+	for _, tld := range []string{"com", "dev", "app", "io"} {
+		cfg := validConfig()
+		cfg.Settings.TLD = tld
+		errs := Validate(cfg)
+		requireError(t, errs, "settings.tld must be one of")
+	}
 }
 
 func TestValidate_Ports(t *testing.T) {

--- a/internal/dns/resolver_test.go
+++ b/internal/dns/resolver_test.go
@@ -52,7 +52,7 @@ func TestResolverFilePath(t *testing.T) {
 	}{
 		{"test", "/etc/resolver/test"},
 		{"localhost", "/etc/resolver/localhost"},
-		{"dev", "/etc/resolver/dev"},
+		{"internal", "/etc/resolver/internal"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Replace `dev` with `internal` in the allowed TLD list (`test`, `localhost`, `local`, `internal`)
- `.dev` is a real public gTLD owned by Google; the macOS resolver file at `/etc/resolver/dev` hijacked ALL `.dev` DNS queries system-wide, breaking Cloudflare tunnels and external services
- Auto-migrate existing configs with `tld: dev` to `internal` on load with a warning
- Clean command now removes orphaned resolver files for formerly-allowed TLDs
- Updated validation, frontend settings dropdown, Makefile dev config, and all docs

Closes #90

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Verify `tld: dev` in config produces a warning and is migrated to `internal`
- [ ] Verify `hatch clean` removes `/etc/resolver/dev` if present
- [ ] Verify dashboard TLD dropdown shows `internal` instead of `dev`